### PR TITLE
refactor actions, included programs from .ghaignore

### DIFF
--- a/.github/.ghaignore
+++ b/.github/.ghaignore
@@ -18,13 +18,6 @@ tokens/spl-token-minter/anchor
 tokens/token-swap/anchor
 tokens/transfer-tokens/anchor
 
-# not building with stable solana
-tokens/token-2022/mint-close-authority/native
-tokens/token-2022/non-transferable/native
-tokens/token-2022/default-account-state/native
-tokens/token-2022/transfer-fee/native
-tokens/token-2022/multiple-extensions/native
-
 # not building
 oracles/pyth/anchor
 
@@ -33,8 +26,3 @@ compression/cutils/anchor
 compression/cnft-vault/anchor
 # builds but need to test on localhost
 compression/cnft-burn/anchor
-
-# not building due to > spl 2.0 dependency issue
-tokens/token-2022/group/anchor
-tokens/token-2022/nft-meta-data-pointer/anchor-example/anchor
-tokens/escrow/anchor

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -72,50 +72,38 @@ jobs:
           fi
 
   build-and-test:
-    needs: changes
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        projects: ${{ fromJson(needs.changes.outputs.project_batches) }}
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Anchor and Solana
-        uses: heyAyushh/setup-anchor@v4.0
-        with:
-          anchor-version: ${{ env.ANCHOR_VERSION }}
-          solana-cli-version: ${{ env.SOLANA_VERSION }}
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
-      - name: Build and Test Projects
-        run: |
-          process_project() {
-            local project=$1
+      needs: changes
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          project: ${{ fromJson(format('[{0}]', needs.changes.outputs.projects)) }}
+        fail-fast: false
+      steps:
+        - uses: actions/checkout@v4
+        - name: Setup Anchor and Solana
+          uses: heyAyushh/setup-anchor@v4.0
+          with:
+            anchor-version: ${{ env.ANCHOR_VERSION }}
+            solana-cli-version: ${{ env.SOLANA_VERSION }}
+        - uses: pnpm/action-setup@v2
+          with:
+            version: 8
+        - name: Build and Test Project
+          run: |
+            project="${{ matrix.project }}"
             echo "Processing $project"
             cd "$project"
-
-            # Build the project
             if ! anchor build; then
               echo "::error file=$project/Cargo.toml::Failed to build $project"
               echo "- :x: $project (Build Failed)" >> $GITHUB_STEP_SUMMARY
-              return 1
+              exit 1
             fi
-
-            # Run tests
             if ! pnpm install --frozen-lockfile || ! anchor test; then
               echo "::error file=$project/Cargo.toml::Failed to test $project"
               echo "- :x: $project (Test Failed)" >> $GITHUB_STEP_SUMMARY
-              return 1
+              exit 1
             fi
             echo "- :white_check_mark: $project" >> $GITHUB_STEP_SUMMARY
-            cd - > /dev/null
-          }
-
-          echo "## Project Results" >> $GITHUB_STEP_SUMMARY
-          for project in ${{ toJson(matrix.projects) }}; do
-            process_project "$project"
-          done
 
   summary:
     needs: build-and-test

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Setup Anchor
         if: steps.changes.outputs.anchor == 'true' || steps.changes.outputs.anchor_action == 'true' || github.event_name == 'schedule' || github.event_name == 'push'
-        uses: heyAyushh/setup-anchor@v3.12
+        uses: heyAyushh/setup-anchor@v3.13
         with:
           anchor-version: ${{ matrix.anchor-version }}
           solana-cli-version: ${{ matrix.solana-version }}
@@ -154,13 +154,13 @@ jobs:
       # Skip Installing and Displaying versions if theres no change in anchor programs or anchor action workflow file or isn't a schedule event
       - name: Setup Anchor
         if: steps.changes.outputs.anchor == 'true' || steps.changes.outputs.anchor_action == 'true' || github.event_name == 'schedule' || github.event_name == 'push'
-        uses: heyAyushh/setup-anchor@v3.12
+        uses: heyAyushh/setup-anchor@v3.13
         with:
           anchor-version: ${{ matrix.anchor-version }}
           solana-cli-version: ${{ matrix.solana-version }}
           node-version: ${{ matrix.node-version }}
       - name: Display versions and Install pnpm
-        if: steps.changes.outputs.anchor == 'true' || steps.changes.outputs.anchor_action == 'true' || github.event_name == 'schedule'
+        if: steps.changes.outputs.anchor == 'true' || steps.changes.outputs.anchor_action == 'true' || github.event_name == 'schedule' || github.event_name == 'push'
         run: |
           solana -V
           solana-keygen new --no-bip39-passphrase
@@ -201,7 +201,7 @@ jobs:
         shell: bash
       # Skip Testing all Programs if it's a CRON job or a change in the workflow file
       - name: Test All Anchor Programs
-        if: github.event_name == 'schedule' || steps.changes.outputs.anchor_action == 'true'
+        if: github.event_name == 'schedule' || github.event_name == 'push' || steps.changes.outputs.anchor_action == 'true'
         run: |
           declare -a ProjectDirs=($(find . -type d -name "anchor"| grep -v -f <(grep . .github/.ghaignore | grep -v '^$')))
           echo "Projects to Test:"

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -1,174 +1,118 @@
 name: Anchor
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened]
-    branches:
-      - main
+    branches: [main]
+
+env:
+  SOLANA_VERSION: 1.18.17
+  ANCHOR_VERSION: 0.30.1
 
 jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
       project_batches: ${{ steps.get-projects.outputs.project_batches }}
-      total_projects: ${{ steps.get-projects.outputs.total_projects }}
-      batch_count: ${{ steps.get-projects.outputs.batch_count }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          list-files: json
-          filters: |
-            anchor:
-              - '**/anchor/**'
-            workflow:
-              - '.github/workflows/anchor.yml'
-            ghaignore:
-              - '.github/.ghaignore'
-      - id: get-projects
+      - name: Get projects to process
+        id: get-projects
         shell: bash
         run: |
-          # Find all anchor project directories
-          get_all_projects() {
-            find . -type d -name "anchor" | sort -u
+          get_changed_projects() {
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              git diff --name-only origin/${{ github.base_ref }} | grep '/anchor/' | sed 's/\/anchor\/.*$/\/anchor/'
+            else
+              find . -type d -name "anchor"
+            fi
           }
 
-          # Check if a project is in the ignore list
-          is_ignored() {
-            local project=$1
-            grep -qE "^${project}$" .github/.ghaignore
+          create_ignore_regex() {
+            grep -v '^#' .github/.ghaignore | sed 's/^/^/' | sed 's/$/\//' | tr '\n' '|' | sed 's/|$//'
           }
 
-          # Get projects that were added to or removed from .ghaignore
-          get_changed_ignored_projects() {
-            git diff origin/main .github/.ghaignore | grep "^[+-]" | grep -v "^[+-][+-]" | sed 's/^[+-]//'
+          filter_projects() {
+            local ignore_regex="$1"
+            if [[ -n "$ignore_regex" ]]; then
+              grep -vE "$ignore_regex" || true
+            else
+              cat
+            fi
           }
 
-          ALL_PROJECTS=$(get_all_projects)
-          WORKFLOW_CHANGED=${{ steps.filter.outputs.workflow }}
-          GHAIGNORE_CHANGED=${{ steps.filter.outputs.ghaignore }}
+          batch_projects() {
+            local batch_size=5
+            jq -R -s 'split("\n")[:-1] | _nwise('"$batch_size"') | map(select(length > 0))'
+          }
 
-          # Determine which projects to process based on the event type and changed files
-          if [[ "$WORKFLOW_CHANGED" == "true" ]]; then
-            echo "Workflow changed. Processing all projects."
-            PROJECTS=$ALL_PROJECTS
-          elif [[ "$GHAIGNORE_CHANGED" == "true" && "${{ github.event_name }}" == "pull_request" ]]; then
-            echo ".ghaignore changed in PR. Processing only changed ignored projects."
-            PROJECTS=$(get_changed_ignored_projects)
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "Processing changed projects for PR."
-            CHANGED=$(echo '${{ steps.filter.outputs.anchor_files }}' | jq -r '.[] | split("/") | .[0:index("anchor")+1] | join("/")')
-            PROJECTS=$CHANGED
-          else
-            echo "Processing all projects for non-PR event."
-            PROJECTS=$ALL_PROJECTS
-          fi
+          ignore_regex=$(create_ignore_regex)
+          projects=$(get_changed_projects | filter_projects "$ignore_regex" | sort -u)
+          batches=$(echo "$projects" | batch_projects)
 
-          # Filter out ignored projects (except when .ghaignore itself changed in a PR)
-          FINAL_PROJECTS=()
-          while IFS= read -r project; do
-            if [[ "$GHAIGNORE_CHANGED" == "true" && "${{ github.event_name }}" == "pull_request" ]] || ! is_ignored "$project"; then
-              FINAL_PROJECTS+=("$project")
-            fi
-          done <<< "$PROJECTS"
-
-          # Debug output
-          echo "Final projects to process:"
-          printf '%s\n' "${FINAL_PROJECTS[@]}"
-
-          # Create batches of projects (max 5 per batch) to stay under job limit
-          BATCH_SIZE=5
-          BATCHES="["
-          BATCH_COUNT=0
-          for ((i=0; i<${#FINAL_PROJECTS[@]}; i+=BATCH_SIZE)); do
-            if [ $i -ne 0 ]; then
-              BATCHES="${BATCHES},"
-            fi
-            END=$((i + BATCH_SIZE))
-            if [ $END -gt ${#FINAL_PROJECTS[@]} ]; then
-              END=${#FINAL_PROJECTS[@]}
-            fi
-            BATCH=$(printf '%s\n' "${FINAL_PROJECTS[@]:i:BATCH_SIZE}" | jq -R . | jq -s .)
-            BATCHES="${BATCHES}${BATCH}"
-            BATCH_COUNT=$((BATCH_COUNT + 1))
-          done
-          BATCHES="${BATCHES}]"
-
-          # Debug output
-          echo "Total projects: ${#FINAL_PROJECTS[@]}"
-          echo "Total batches: $BATCH_COUNT"
-          echo "Batches created:"
-          echo "$BATCHES" | jq .
-
-          # Output project batches as JSON array and total count
-          echo "project_batches=$BATCHES" >> $GITHUB_OUTPUT
-          echo "total_projects=${#FINAL_PROJECTS[@]}" >> $GITHUB_OUTPUT
-          echo "batch_count=$BATCH_COUNT" >> $GITHUB_OUTPUT
+          echo "project_batches=$batches" >> $GITHUB_OUTPUT
+          echo "::notice::Projects to process: $projects"
 
   build-and-test:
     needs: changes
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        batch: ${{ fromJson(needs.changes.outputs.project_batches) }}
-        include:
-          - solana-version: 1.18.17
-            anchor-version: 0.30.1
+        projects: ${{ fromJson(needs.changes.outputs.project_batches) }}
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: heyAyushh/setup-anchor@v4.0
+      - name: Setup Anchor and Solana
+        uses: heyAyushh/setup-anchor@v4.0
         with:
-          anchor-version: ${{ matrix.anchor-version }}
-          solana-cli-version: ${{ matrix.solana-version }}
+          anchor-version: ${{ env.ANCHOR_VERSION }}
+          solana-cli-version: ${{ env.SOLANA_VERSION }}
       - uses: pnpm/action-setup@v2
         with:
           version: 8
-      - name: Build and Test Batch
+      - name: Build and Test Projects
         run: |
-          echo "Processing batch: ${{ toJson(matrix.batch) }}"
-          for project in ${{ toJson(matrix.batch) }}; do
-            project=$(echo $project | jq -r '.')
+          process_project() {
+            local project=$1
             echo "Processing $project"
             cd "$project"
 
             # Build the project
             if ! anchor build; then
-              echo "::warning file=$project/Cargo.toml::Failed to build $project"
-              echo "$project - :x: Build Failed" >> $GITHUB_STEP_SUMMARY
-              cd - > /dev/null
-              continue
+              echo "::error file=$project/Cargo.toml::Failed to build $project"
+              echo "- :x: $project (Build Failed)" >> $GITHUB_STEP_SUMMARY
+              return 1
             fi
 
             # Run tests
             if ! pnpm install --frozen-lockfile || ! anchor test; then
-              echo "::warning file=$project/Cargo.toml::Failed to test $project"
-              echo "$project - :x: Test Failed" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "$project - :white_check_mark: Passed" >> $GITHUB_STEP_SUMMARY
+              echo "::error file=$project/Cargo.toml::Failed to test $project"
+              echo "- :x: $project (Test Failed)" >> $GITHUB_STEP_SUMMARY
+              return 1
             fi
+            echo "- :white_check_mark: $project" >> $GITHUB_STEP_SUMMARY
             cd - > /dev/null
+          }
+
+          echo "## Project Results" >> $GITHUB_STEP_SUMMARY
+          for project in ${{ toJson(matrix.projects) }}; do
+            process_project "$project"
           done
 
   summary:
-    needs: [changes, build-and-test]
+    needs: build-and-test
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Summary
         run: |
           echo "## Anchor Workflow Summary" >> $GITHUB_STEP_SUMMARY
-          echo "Total projects processed: ${{ needs.changes.outputs.total_projects }}" >> $GITHUB_STEP_SUMMARY
-          echo "Total batches: ${{ needs.changes.outputs.batch_count }}" >> $GITHUB_STEP_SUMMARY
-          echo "Check individual job logs for details on warnings and failures." >> $GITHUB_STEP_SUMMARY
+          echo "Solana Version: ${{ env.SOLANA_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "Anchor Version: ${{ env.ANCHOR_VERSION }}" >> $GITHUB_STEP_SUMMARY
           if [[ "${{ needs.build-and-test.result }}" == "success" ]]; then
-            echo ":white_check_mark: All projects completed (with potential warnings)" >> $GITHUB_STEP_SUMMARY
+            echo ":white_check_mark: All projects completed successfully" >> $GITHUB_STEP_SUMMARY
           else
             echo ":x: Some projects encountered errors" >> $GITHUB_STEP_SUMMARY
           fi
+          echo "Check individual job logs for details on errors and failures." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -23,7 +23,9 @@ jobs:
         run: |
           get_changed_projects() {
             if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              git diff --name-only origin/${{ github.base_ref }} | grep '/anchor/' | sed 's/\/anchor\/.*$/\/anchor/'
+              git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '/anchor/' | sed 's/\/anchor\/.*$/\/anchor/'
+            elif [[ "${{ github.event_name }}" == "push" ]]; then
+              git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | grep '/anchor/' | sed 's/\/anchor\/.*$/\/anchor/'
             else
               find . -type d -name "anchor"
             fi

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -77,19 +77,38 @@ jobs:
             fi
           done <<< "$PROJECTS"
 
-          # Create batches of projects (max 50 per batch) to stay under job limit
-          # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#using-a-matrix-strategy
-          BATCH_SIZE=5
-          BATCHES=()
-          for ((i=0; i<${#FINAL_PROJECTS[@]}; i+=BATCH_SIZE)); do
-            BATCH="${FINAL_PROJECTS[@]:i:BATCH_SIZE}"
-            BATCHES+=("$BATCH")
-          done
+          # Debug output
+          echo "Final projects to process:"
+          printf '%s\n' "${FINAL_PROJECTS[@]}"
 
-          # Output project batches as space-separated strings and total count
-          echo "project_batches<<EOF" >> $GITHUB_OUTPUT
-          printf "%s\n" "${BATCHES[@]}" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          # Ensure we always have at least one batch, even if it's empty
+          if [ ${#FINAL_PROJECTS[@]} -eq 0 ]; then
+            echo "No projects to process, creating EMPTY batch."
+            BATCHES='[["EMPTY"]]'
+          else
+            # Create batches of projects (max 5 per batch) to stay under job limit
+            BATCH_SIZE=5
+            BATCHES="["
+            for ((i=0; i<${#FINAL_PROJECTS[@]}; i+=BATCH_SIZE)); do
+              if [ $i -ne 0 ]; then
+                BATCHES="${BATCHES},"
+              fi
+              END=$((i + BATCH_SIZE))
+              if [ $END -gt ${#FINAL_PROJECTS[@]} ]; then
+                END=${#FINAL_PROJECTS[@]}
+              fi
+              BATCH=$(printf '%s\n' "${FINAL_PROJECTS[@]:i:BATCH_SIZE}" | jq -R . | jq -s .)
+              BATCHES="${BATCHES}${BATCH}"
+            done
+            BATCHES="${BATCHES}]"
+          fi
+
+          # Debug output
+          echo "Batches created:"
+          echo "$BATCHES"
+
+          # Output project batches as JSON array and total count
+          echo "project_batches=$BATCHES" >> $GITHUB_OUTPUT
           echo "total_projects=${#FINAL_PROJECTS[@]}" >> $GITHUB_OUTPUT
 
   build-and-test:
@@ -113,28 +132,32 @@ jobs:
           version: 8
       - name: Build and Test Batch
         run: |
-          # Process each project in the batch
-          for project in ${{ matrix.batch }}; do
-            echo "Processing $project"
-            cd "$project"
+          if [ "${{ contains(matrix.batch, 'EMPTY') }}" = "true" ]; then
+            echo "No projects to process in this batch."
+          else
+            # Process each project in the batch
+            for project in ${{ join(matrix.batch, ' ') }}; do
+              echo "Processing $project"
+              cd "$project"
 
-            # Build the project
-            if ! anchor build; then
-              echo "::warning file=$project/Cargo.toml::Failed to build $project"
-              echo "$project - :x: Build Failed" >> $GITHUB_STEP_SUMMARY
+              # Build the project
+              if ! anchor build; then
+                echo "::warning file=$project/Cargo.toml::Failed to build $project"
+                echo "$project - :x: Build Failed" >> $GITHUB_STEP_SUMMARY
+                cd - > /dev/null
+                continue
+              fi
+
+              # Run tests
+              if ! pnpm install --frozen-lockfile || ! anchor test; then
+                echo "::warning file=$project/Cargo.toml::Failed to test $project"
+                echo "$project - :x: Test Failed" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "$project - :white_check_mark: Passed" >> $GITHUB_STEP_SUMMARY
+              fi
               cd - > /dev/null
-              continue
-            fi
-
-            # Run tests
-            if ! pnpm install --frozen-lockfile || ! anchor test; then
-              echo "::warning file=$project/Cargo.toml::Failed to test $project"
-              echo "$project - :x: Test Failed" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "$project - :white_check_mark: Passed" >> $GITHUB_STEP_SUMMARY
-            fi
-            cd - > /dev/null
-          done
+            done
+          fi
 
   summary:
     needs: build-and-test

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -83,11 +83,13 @@ jobs:
           BATCHES=()
           for ((i=0; i<${#FINAL_PROJECTS[@]}; i+=BATCH_SIZE)); do
             BATCH="${FINAL_PROJECTS[@]:i:BATCH_SIZE}"
-            BATCHES+=("$(echo $BATCH | jq -R 'split(" ")')")
+            BATCHES+=("$BATCH")
           done
 
-          # Output project batches and total count
-          echo "project_batches=$(echo "${BATCHES[@]}" | jq -s -c .)" >> $GITHUB_OUTPUT
+          # Output project batches as space-separated strings and total count
+          echo "project_batches<<EOF" >> $GITHUB_OUTPUT
+          printf "%s\n" "${BATCHES[@]}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
           echo "total_projects=${#FINAL_PROJECTS[@]}" >> $GITHUB_OUTPUT
 
   build-and-test:
@@ -110,19 +112,17 @@ jobs:
         with:
           version: 8
       - name: Build and Test Batch
-        shell: bash
         run: |
           # Process each project in the batch
-          for project in ${{ toJson(matrix.batch) }}; do
-            project=$(echo $project | jq -r '.')
+          for project in ${{ matrix.batch }}; do
             echo "Processing $project"
-            cd $project
+            cd "$project"
 
             # Build the project
             if ! anchor build; then
               echo "::warning file=$project/Cargo.toml::Failed to build $project"
               echo "$project - :x: Build Failed" >> $GITHUB_STEP_SUMMARY
-              cd -
+              cd - > /dev/null
               continue
             fi
 
@@ -133,7 +133,7 @@ jobs:
             else
               echo "$project - :white_check_mark: Passed" >> $GITHUB_STEP_SUMMARY
             fi
-            cd -
+            cd - > /dev/null
           done
 
   summary:

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -12,223 +12,141 @@ on:
       - main
 
 jobs:
-  build:
+  changes:
     runs-on: ubuntu-latest
-    permissions:
-        pull-requests: read
-    strategy:
-      matrix:
-        node-version: [20.x]
-        solana-version: [1.18.17, stable]
-        anchor-version: [0.30.1]
+    outputs:
+      project_batches: ${{ steps.get-projects.outputs.project_batches }}
+      total_projects: ${{ steps.get-projects.outputs.total_projects }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
-        if: github.event_name == 'pull_request'
-        id: changes
+        id: filter
         with:
-          list-files: shell
+          list-files: json
           filters: |
             anchor:
-              - added|modified: '**/anchor/**'
-            anchor_action:
-              - added|modified: '**/workflows/anchor.yml'
-
-      - name: Setup Anchor
-        if: steps.changes.outputs.anchor == 'true' || steps.changes.outputs.anchor_action == 'true' || github.event_name == 'schedule' || github.event_name == 'push'
-        uses: heyAyushh/setup-anchor@v4.0
-        with:
-          anchor-version: ${{ matrix.anchor-version }}
-          solana-cli-version: ${{ matrix.solana-version }}
-          node-version: ${{ matrix.node-version }}
-      - name: Display versions and Install pnpm
-        if: steps.changes.outputs.anchor == 'true' || steps.changes.outputs.anchor_action == 'true' || github.event_name == 'schedule'
+              - '**/anchor/**'
+            workflow:
+              - '.github/workflows/anchor.yml'
+            ghaignore:
+              - '.github/.ghaignore'
+      - id: get-projects
         run: |
-          solana -V
-          solana-keygen new --no-bip39-passphrase
-          rustc -V
-          anchor -V
-          npm i -g pnpm
-      # Run only if it's triggered by PR to main,
-      # Build the changed programs
-      - name: Build Changed Anchor programs
-        if: steps.changes.outputs.anchor == 'true' && steps.changes.outputs.anchor_action != 'true'
-        run: |
-            changed_files=(${{ steps.changes.outputs.anchor_files }})
+          # Find all anchor project directories
+          get_all_projects() {
+            find . -type d -name "anchor" | sort -u
+          }
 
-            # Read ignored projects from .github/.ghaignore, ignoring empty lines and comments
-            ignored_projects=($(grep . .github/.ghaignore | grep -v '^$'))
+          # Check if a project is in the ignore list
+          is_ignored() {
+            local project=$1
+            grep -qE "^${project}$" .github/.ghaignore
+          }
 
-            # Find anchor projects and remove ignored projects
-            ProjectDirs=($(for file in "${changed_files[@]}"; do
-              anchor_path=$(dirname "${file}" | grep anchor | sed 's#/anchor/.*#/anchor#g')
-              if [[ ! " ${ignored_projects[*]} " =~ " ${anchor_path} " ]]; then
-                echo "$anchor_path"
-              fi
-            done | sort -u))
+          # Get projects that were added to or removed from .ghaignore
+          get_changed_ignored_projects() {
+            git diff origin/main .github/.ghaignore | grep "^[+-]" | grep -v "^[+-][+-]" | sed 's/^[+-]//'
+          }
 
-            # Build anchor projects
-            echo "Projects to Build:"
-            printf "%s\n" "${ProjectDirs[@]}"
-            for projectDir in "${ProjectDirs[@]}"; do
-              echo "
-              ********
-              Building $projectDir
-              ********"
-              cd $projectDir
-              if anchor build; then
-                echo "Build succeeded for $projectDir."
-                rm -rf target
-              else
-                failed=true
-                failed_builds+=($projectDir)
-                echo "Build failed for $projectDir. Continuing with the next program."
-              fi
-              cd - > /dev/null
-            done
-            if [ "$failed" = true ]; then
-              echo "Programs that failed building:"
-              printf "%s\n" "${failed_builds[@]}"
-              exit 1
-            else
-              echo "All programs built successfully."
-            fi
-        shell: bash
-      # Skip Building all Programs if it's a PR to main branch
-      - name: Build All Anchor programs
-        if: github.event_name == 'schedule' || github.event_name == 'push' || steps.changes.outputs.anchor_action == 'true'
-        run: |
-          # Find all anchor projects and remove ignored projects
-          declare -a ProjectDirs=($(find . -type d -name 'anchor' | sed 's|^\./||'| grep -v -f <(grep . .github/.ghaignore | grep -v '^$')))
+          ALL_PROJECTS=$(get_all_projects)
+          WORKFLOW_CHANGED=${{ steps.filter.outputs.workflow }}
+          GHAIGNORE_CHANGED=${{ steps.filter.outputs.ghaignore }}
 
-          echo "Projects to Build:"
-          printf "%s\n" "${ProjectDirs[@]}"
-
-          # Build anchor projects
-          for projectDir in "${ProjectDirs[@]}"; do
-            echo "
-            ********
-            Building $projectDir
-            ********"
-            cd $projectDir
-            if anchor build; then
-              echo "Build succeeded for $projectDir."
-              rm -rf target
-            else
-              failed=true
-              failed_builds+=($projectDir)
-              echo "Build failed for $projectDir. Continuing with the next program."
-            fi
-          cd - > /dev/null
-          done
-          if [ "$failed" = true ]; then
-            echo "Programs that failed building:"
-            printf "%s\n" "${failed_builds[@]}"
-            exit 1
+          # Determine which projects to process based on the event type and changed files
+          if [[ "$WORKFLOW_CHANGED" == "true" ]]; then
+            echo "Workflow changed. Processing all projects."
+            PROJECTS=$ALL_PROJECTS
+          elif [[ "$GHAIGNORE_CHANGED" == "true" && "${{ github.event_name }}" == "pull_request" ]]; then
+            echo ".ghaignore changed in PR. Processing only changed ignored projects."
+            PROJECTS=$(get_changed_ignored_projects)
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "Processing changed projects for PR."
+            CHANGED=$(echo '${{ steps.filter.outputs.anchor_files }}' | jq -r '.[] | split("/") | .[0:index("anchor")+1] | join("/")')
+            PROJECTS=$CHANGED
           else
-            echo "All programs built successfully."
+            echo "Processing all projects for non-PR event."
+            PROJECTS=$ALL_PROJECTS
           fi
-        shell: bash
 
-  test:
+          # Filter out ignored projects (except when .ghaignore itself changed in a PR)
+          FINAL_PROJECTS=()
+          while IFS= read -r project; do
+            if [[ "$GHAIGNORE_CHANGED" == "true" && "${{ github.event_name }}" == "pull_request" ]] || ! is_ignored "$project"; then
+              FINAL_PROJECTS+=("$project")
+            fi
+          done <<< "$PROJECTS"
+
+          # Create batches of projects (max 50 per batch) to stay under job limit
+          # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#using-a-matrix-strategy
+          BATCH_SIZE=5
+          BATCHES=()
+          for ((i=0; i<${#FINAL_PROJECTS[@]}; i+=BATCH_SIZE)); do
+            BATCH="${FINAL_PROJECTS[@]:i:BATCH_SIZE}"
+            BATCHES+=("$(echo $BATCH | jq -R 'split(" ")')")
+          done
+
+          # Output project batches and total count
+          echo "project_batches=$(echo "${BATCHES[@]}" | jq -s -c .)" >> $GITHUB_OUTPUT
+          echo "total_projects=${#FINAL_PROJECTS[@]}" >> $GITHUB_OUTPUT
+
+  build-and-test:
+    needs: changes
     runs-on: ubuntu-latest
-    permissions:
-          pull-requests: read
     strategy:
       matrix:
-        node-version: [20.x]
-        solana-version: [1.18.17, stable]
-        anchor-version: [0.30.1]
+        batch: ${{ fromJson(needs.changes.outputs.project_batches) }}
+        include:
+          - solana-version: 1.18.17
+            anchor-version: 0.30.1
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        if: github.event_name == 'pull_request'
-        id: changes
-        with:
-          list-files: shell
-          filters: |
-            anchor:
-              - added|modified: '**/anchor/**'
-            anchor_action:
-              - added|modified: '**/workflows/anchor.yml'
-      # Skip Installing and Displaying versions if theres no change in anchor programs or anchor action workflow file or isn't a schedule event
-      - name: Setup Anchor
-        if: steps.changes.outputs.anchor == 'true' || steps.changes.outputs.anchor_action == 'true' || github.event_name == 'schedule' || github.event_name == 'push'
-        uses: heyAyushh/setup-anchor@v4.0
+      - uses: heyAyushh/setup-anchor@v4.0
         with:
           anchor-version: ${{ matrix.anchor-version }}
           solana-cli-version: ${{ matrix.solana-version }}
-          node-version: ${{ matrix.node-version }}
-      - name: Display versions and Install pnpm
-        if: steps.changes.outputs.anchor == 'true' || steps.changes.outputs.anchor_action == 'true' || github.event_name == 'schedule' || github.event_name == 'push'
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Build and Test Batch
         run: |
-          solana -V
-          solana-keygen new --no-bip39-passphrase
-          rustc -V
-          anchor -V
-          npm i -g pnpm
-      - name: Test Changed Anchor Programs
-        if: steps.changes.outputs.anchor == 'true' && steps.changes.outputs.anchor_action != 'true'
-        run: |
-          changed_files=(${{ steps.changes.outputs.anchor_files }})
-          ProjectDirs=($(for file in "${changed_files[@]}"; do dirname "${file}" | grep anchor | sed 's#/anchor/.*#/anchor#g'; done | grep -v -f <(grep . .github/.ghaignore | grep -v '^$') | sort -u))
-          echo "Projects to Test:"
-          printf "%s\n" "${ProjectDirs[@]}"
-          for projectDir in "${ProjectDirs[@]}"; do
-            echo "
-            ********
-            Testing $projectDir
-            ********"
-            cd $projectDir
-            if pnpm install --frozen-lockfile && anchor test; then
-              echo "Tests succeeded for $projectDir."
-              rm -rf target node_modules
-            else
-              failed=true
-              failed_tests+=($projectDir)
-              echo "Tests failed for $val. Continuing with the next program."
+          # Process each project in the batch
+          for project in ${{ toJson(matrix.batch) }}; do
+            project=$(echo $project | jq -r '.')
+            echo "Processing $project"
+            cd $project
+
+            # Build the project
+            if ! anchor build; then
+              echo "::warning file=$project/Cargo.toml::Failed to build $project"
+              echo "$project - :x: Build Failed" >> $GITHUB_STEP_SUMMARY
+              cd -
+              continue
             fi
-          cd - > /dev/null
-          done
-          if [ "$failed" = true ]; then
-            echo "*****************************"
-            echo "Programs that failed testing:"
-            printf "%s\n" "${failed_tests[@]}"
-            exit 1
-          else
-            echo "All tests passed."
-          fi
-        shell: bash
-      # Skip Testing all Programs if it's a CRON job or a change in the workflow file
-      - name: Test All Anchor Programs
-        if: github.event_name == 'schedule' || github.event_name == 'push' || steps.changes.outputs.anchor_action == 'true'
-        run: |
-          declare -a ProjectDirs=($(find . -type d -name "anchor"| grep -v -f <(grep . .github/.ghaignore | grep -v '^$')))
-          echo "Projects to Test:"
-          printf "%s\n" "${ProjectDirs[@]}"
-          for projectDir in "${ProjectDirs[@]}"; do
-            echo "
-            ********
-            Testing $projectDir
-            ********"
-            cd $projectDir
-            pnpm install --frozen-lockfile
-            if anchor test; then
-              echo "Tests succeeded for $projectDir."
-              rm -rf target node_modules
+
+            # Run tests
+            if ! pnpm install --frozen-lockfile || ! anchor test; then
+              echo "::warning file=$project/Cargo.toml::Failed to test $project"
+              echo "$project - :x: Test Failed" >> $GITHUB_STEP_SUMMARY
             else
-              failed=true
-              failed_tests+=($projectDir)
-              echo "Tests failed for $val. Continuing with the next program."
+              echo "$project - :white_check_mark: Passed" >> $GITHUB_STEP_SUMMARY
             fi
-          cd - > /dev/null
+            cd -
           done
-          if [ "$failed" = true ]; then
-            echo "*****************************"
-            echo "Programs that failed testing:"
-            printf "%s\n" "${failed_tests[@]}"
-            exit 1
+
+  summary:
+    needs: [changes, build-and-test]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Summary
+        run: |
+          # Provide overall workflow summary
+          echo "## Anchor Workflow Summary" >> $GITHUB_STEP_SUMMARY
+          echo "Total projects processed: ${{ needs.changes.outputs.total_projects }}" >> $GITHUB_STEP_SUMMARY
+          echo "Check individual job logs for details on warnings and failures." >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ needs.build-and-test.result }}" == "success" ]]; then
+            echo ":white_check_mark: All projects completed (with potential warnings)" >> $GITHUB_STEP_SUMMARY
           else
-            echo "All tests passed."
+            echo ":x: Some projects encountered errors" >> $GITHUB_STEP_SUMMARY
           fi
-        shell: bash

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -31,6 +31,7 @@ jobs:
             ghaignore:
               - '.github/.ghaignore'
       - id: get-projects
+        shell: bash
         run: |
           # Find all anchor project directories
           get_all_projects() {
@@ -109,6 +110,7 @@ jobs:
         with:
           version: 8
       - name: Build and Test Batch
+        shell: bash
         run: |
           # Process each project in the batch
           for project in ${{ toJson(matrix.batch) }}; do

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -137,7 +137,7 @@ jobs:
           done
 
   summary:
-    needs: [changes, build-and-test]
+    needs: build-and-test
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -21,40 +21,55 @@ jobs:
         id: get-projects
         shell: bash
         run: |
+          set -e
           get_changed_projects() {
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep '/anchor/' | sed 's/\/anchor\/.*$/\/anchor/'
-            elif [[ "${{ github.event_name }}" == "push" ]]; then
-              git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | grep '/anchor/' | sed 's/\/anchor\/.*$/\/anchor/'
-            else
-              find . -type d -name "anchor"
-            fi
+              if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+                git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} || echo "Git diff failed"
+              elif [[ "${{ github.event_name }}" == "push" ]]; then
+                git diff --name-only ${{ github.event.before }} ${{ github.event.after }} || echo "Git diff failed"
+              else
+                echo "Not a pull request or push event"
+              fi
           }
 
           create_ignore_regex() {
-            grep -v '^#' .github/.ghaignore | sed 's/^/^/' | sed 's/$/\//' | tr '\n' '|' | sed 's/|$//'
+              grep -v '^#' .github/.ghaignore 2>/dev/null | sed 's/^/^/' | sed 's/$/\//' | tr '\n' '|' | sed 's/|$//' || echo ""
           }
 
           filter_projects() {
-            local ignore_regex="$1"
-            if [[ -n "$ignore_regex" ]]; then
-              grep -vE "$ignore_regex" || true
-            else
-              cat
-            fi
+              local ignore_regex="$1"
+              if [[ -n "$ignore_regex" ]]; then
+                grep -vE "$ignore_regex" || true
+              else
+                cat
+              fi
           }
 
           batch_projects() {
-            local batch_size=5
-            jq -R -s 'split("\n")[:-1] | _nwise('"$batch_size"') | map(select(length > 0))'
+              local batch_size=5
+              jq -R -s 'split("\n")[:-1] | _nwise('"$batch_size"') | map(select(length > 0))'
           }
 
           ignore_regex=$(create_ignore_regex)
-          projects=$(get_changed_projects | filter_projects "$ignore_regex" | sort -u)
-          batches=$(echo "$projects" | batch_projects)
+          changed_files=$(get_changed_projects)
 
-          echo "project_batches=$batches" >> $GITHUB_OUTPUT
-          echo "::notice::Projects to process: $projects"
+          if [[ $changed_files == *"Git diff failed"* || $changed_files == *"Not a pull request or push event"* ]]; then
+              echo "::warning::Failed to get changed files. Processing all projects."
+              projects=$(find . -type d -name "anchor")
+          else
+              projects=$(echo "$changed_files" | grep '/anchor/' | sed 's/\/anchor\/.*$/\/anchor/' | sort -u)
+          fi
+
+          filtered_projects=$(echo "$projects" | filter_projects "$ignore_regex")
+
+          if [[ -z "$filtered_projects" ]]; then
+              echo "::notice::No projects to process after filtering."
+              echo "project_batches=[]" >> $GITHUB_OUTPUT
+          else
+              batches=$(echo "$filtered_projects" | batch_projects)
+              echo "project_batches=$batches" >> $GITHUB_OUTPUT
+              echo "::notice::Projects to process: $filtered_projects"
+          fi
 
   build-and-test:
     needs: changes

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       project_batches: ${{ steps.get-projects.outputs.project_batches }}
       total_projects: ${{ steps.get-projects.outputs.total_projects }}
+      batch_count: ${{ steps.get-projects.outputs.batch_count }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -81,35 +82,34 @@ jobs:
           echo "Final projects to process:"
           printf '%s\n' "${FINAL_PROJECTS[@]}"
 
-          # Ensure we always have at least one batch, even if it's empty
-          if [ ${#FINAL_PROJECTS[@]} -eq 0 ]; then
-            echo "No projects to process, creating EMPTY batch."
-            BATCHES='[["EMPTY"]]'
-          else
-            # Create batches of projects (max 5 per batch) to stay under job limit
-            BATCH_SIZE=5
-            BATCHES="["
-            for ((i=0; i<${#FINAL_PROJECTS[@]}; i+=BATCH_SIZE)); do
-              if [ $i -ne 0 ]; then
-                BATCHES="${BATCHES},"
-              fi
-              END=$((i + BATCH_SIZE))
-              if [ $END -gt ${#FINAL_PROJECTS[@]} ]; then
-                END=${#FINAL_PROJECTS[@]}
-              fi
-              BATCH=$(printf '%s\n' "${FINAL_PROJECTS[@]:i:BATCH_SIZE}" | jq -R . | jq -s .)
-              BATCHES="${BATCHES}${BATCH}"
-            done
-            BATCHES="${BATCHES}]"
-          fi
+          # Create batches of projects (max 5 per batch) to stay under job limit
+          BATCH_SIZE=5
+          BATCHES="["
+          BATCH_COUNT=0
+          for ((i=0; i<${#FINAL_PROJECTS[@]}; i+=BATCH_SIZE)); do
+            if [ $i -ne 0 ]; then
+              BATCHES="${BATCHES},"
+            fi
+            END=$((i + BATCH_SIZE))
+            if [ $END -gt ${#FINAL_PROJECTS[@]} ]; then
+              END=${#FINAL_PROJECTS[@]}
+            fi
+            BATCH=$(printf '%s\n' "${FINAL_PROJECTS[@]:i:BATCH_SIZE}" | jq -R . | jq -s .)
+            BATCHES="${BATCHES}${BATCH}"
+            BATCH_COUNT=$((BATCH_COUNT + 1))
+          done
+          BATCHES="${BATCHES}]"
 
           # Debug output
+          echo "Total projects: ${#FINAL_PROJECTS[@]}"
+          echo "Total batches: $BATCH_COUNT"
           echo "Batches created:"
-          echo "$BATCHES"
+          echo "$BATCHES" | jq .
 
           # Output project batches as JSON array and total count
           echo "project_batches=$BATCHES" >> $GITHUB_OUTPUT
           echo "total_projects=${#FINAL_PROJECTS[@]}" >> $GITHUB_OUTPUT
+          echo "batch_count=$BATCH_COUNT" >> $GITHUB_OUTPUT
 
   build-and-test:
     needs: changes
@@ -132,43 +132,40 @@ jobs:
           version: 8
       - name: Build and Test Batch
         run: |
-          if [ "${{ contains(matrix.batch, 'EMPTY') }}" = "true" ]; then
-            echo "No projects to process in this batch."
-          else
-            # Process each project in the batch
-            for project in ${{ join(matrix.batch, ' ') }}; do
-              echo "Processing $project"
-              cd "$project"
+          echo "Processing batch: ${{ toJson(matrix.batch) }}"
+          for project in ${{ toJson(matrix.batch) }}; do
+            project=$(echo $project | jq -r '.')
+            echo "Processing $project"
+            cd "$project"
 
-              # Build the project
-              if ! anchor build; then
-                echo "::warning file=$project/Cargo.toml::Failed to build $project"
-                echo "$project - :x: Build Failed" >> $GITHUB_STEP_SUMMARY
-                cd - > /dev/null
-                continue
-              fi
-
-              # Run tests
-              if ! pnpm install --frozen-lockfile || ! anchor test; then
-                echo "::warning file=$project/Cargo.toml::Failed to test $project"
-                echo "$project - :x: Test Failed" >> $GITHUB_STEP_SUMMARY
-              else
-                echo "$project - :white_check_mark: Passed" >> $GITHUB_STEP_SUMMARY
-              fi
+            # Build the project
+            if ! anchor build; then
+              echo "::warning file=$project/Cargo.toml::Failed to build $project"
+              echo "$project - :x: Build Failed" >> $GITHUB_STEP_SUMMARY
               cd - > /dev/null
-            done
-          fi
+              continue
+            fi
+
+            # Run tests
+            if ! pnpm install --frozen-lockfile || ! anchor test; then
+              echo "::warning file=$project/Cargo.toml::Failed to test $project"
+              echo "$project - :x: Test Failed" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "$project - :white_check_mark: Passed" >> $GITHUB_STEP_SUMMARY
+            fi
+            cd - > /dev/null
+          done
 
   summary:
-    needs: build-and-test
+    needs: [changes, build-and-test]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Summary
         run: |
-          # Provide overall workflow summary
           echo "## Anchor Workflow Summary" >> $GITHUB_STEP_SUMMARY
           echo "Total projects processed: ${{ needs.changes.outputs.total_projects }}" >> $GITHUB_STEP_SUMMARY
+          echo "Total batches: ${{ needs.changes.outputs.batch_count }}" >> $GITHUB_STEP_SUMMARY
           echo "Check individual job logs for details on warnings and failures." >> $GITHUB_STEP_SUMMARY
           if [[ "${{ needs.build-and-test.result }}" == "success" ]]; then
             echo ":white_check_mark: All projects completed (with potential warnings)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/solana-native.yml
+++ b/.github/workflows/solana-native.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x]
-        solana-version: [1.17.25, stable]
+        solana-version: [1.18.17, stable]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/tokens/token-2022/default-account-state/native/program/Cargo.toml
+++ b/tokens/token-2022/default-account-state/native/program/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 borsh = "0.9.3"
 borsh-derive = "0.9.1"
-solana-program = "1.17.25"
+solana-program = "1.18.17"
 spl-associated-token-account = { version="2.0.0", features = [ "no-entrypoint" ] }
 spl-token-2022 = {version = "0.7.0", features = [ "no-entrypoint" ] }
 

--- a/tokens/token-2022/multiple-extensions/native/program/Cargo.toml
+++ b/tokens/token-2022/multiple-extensions/native/program/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 borsh = "0.9.3"
 borsh-derive = "0.9.1"
-solana-program = "1.17.25"
+solana-program = "1.18.17"
 spl-associated-token-account = { version="2.0.0", features = [ "no-entrypoint" ] }
 spl-token-2022 = {version = "0.7.0", features = [ "no-entrypoint" ] }
 

--- a/tokens/token-2022/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/Cargo.toml
+++ b/tokens/token-2022/nft-meta-data-pointer/anchor-example/anchor/programs/extension_nft/Cargo.toml
@@ -20,7 +20,7 @@ idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 anchor-lang = { version = "0.30.0", features = ["init-if-needed"] }
 anchor-spl = { version = "0.30.0" }
 session-keys = { version = "2.0.3", features = ["no-entrypoint"] }
-solana-program = "1.17.25"
+solana-program = "1.18.17"
 spl-token-2022 = { version="2.0.1", features = [ "no-entrypoint" ] }
 spl-token = { version = "4.0.1", features = [ "no-entrypoint" ] }
 spl-token-metadata-interface = { version = "0.2.1"}

--- a/tokens/token-2022/non-transferable/native/program/Cargo.toml
+++ b/tokens/token-2022/non-transferable/native/program/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 borsh = "0.9.3"
 borsh-derive = "0.9.1"
-solana-program = "=1.17.25"
+solana-program = "=1.18.17"
 spl-associated-token-account = { version="2.0.0", features = [ "no-entrypoint" ] }
 spl-token-2022 = {version = "0.7.0", features = [ "no-entrypoint" ] }
 

--- a/tokens/token-2022/transfer-fee/native/program/Cargo.toml
+++ b/tokens/token-2022/transfer-fee/native/program/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 borsh = "0.10.3"
 borsh-derive = "0.9.1"
-solana-program = "=1.17.25"
+solana-program = "=1.18.17"
 spl-associated-token-account = { version="2.0.0", features = [ "no-entrypoint" ] }
 spl-token-2022 = {version = "0.7.0", features = [ "no-entrypoint" ] }
 


### PR DESCRIPTION
Do squash and merge.

Some projects were ignored when Stable solana was breaking because of dependency issue, 
removing the names so that they can be built again.