### PR TITLE
Fix mint_token function to account for token decimals

### DIFF
--- a/tokens/token-2022/basics/anchor/programs/basics/src/lib.rs
+++ b/tokens/token-2022/basics/anchor/programs/basics/src/lib.rs
@@ -46,9 +46,10 @@ pub mod anchor {
             to: ctx.accounts.receiver.to_account_info().clone(),
             authority: ctx.accounts.signer.to_account_info(),
         };
+    
         let cpi_program = ctx.accounts.token_program.to_account_info();
         let cpi_context = CpiContext::new(cpi_program, cpi_accounts);
-        token_interface::mint_to(cpi_context, amount)?;
+        token_interface::mint_to(cpi_context,  amount * 10u64.pow(ctx.accounts.mint.decimals as u32))?;
         msg!("Mint Token");
         Ok(())
     }


### PR DESCRIPTION
**Description**

the mint_token function in tokens/token-2022/basics/anchor/programs/basics/src/lib.rs file does not correctly account for the token's decimal places, leading to incorrect minting amounts.

**Proposed Solution**

Update the `mint_token` function to correctly handle token decimals. 

**Updated Code:**
```rust
pub fn mint_token(ctx: Context<MintToken>, amount: u64) -> Result<()> {
    let cpi_accounts = MintTo {
        mint: ctx.accounts.mint.to_account_info().clone(),
        to: ctx.accounts.receiver.to_account_info().clone(),
        authority: ctx.accounts.signer.to_account_info(),
    };

    let cpi_program = ctx.accounts.token_program.to_account_info();
    let cpi_context = CpiContext::new(cpi_program, cpi_accounts);
    token_interface::mint_to(cpi_context, amount * 10u64.pow(ctx.accounts.mint.decimals as u32))?;
    msg!("Mint Token");
    Ok(())
}
```


Thank you! 🙏