### PR TITLE
Add transfer-hook-transfer-switch example using Anchor 

### DIFF
--- a/tokens/transfer-hook-transfer-switch/anchor/.gitignore
+++ b/tokens/transfer-hook-transfer-switch/anchor/.gitignore
@@ -1,0 +1,7 @@
+
+.anchor
+.DS_Store
+target
+**/*.rs.bk
+node_modules
+test-ledger

--- a/tokens/transfer-hook-transfer-switch/anchor/Anchor.toml
+++ b/tokens/transfer-hook-transfer-switch/anchor/Anchor.toml
@@ -1,0 +1,15 @@
+[features]
+seeds = false
+skip-lint = false
+[programs.localnet]
+transfer_hook_transfer_switch = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+
+[registry]
+url = "https://api.apr.dev"
+
+[provider]
+cluster = "Localnet"
+wallet = "/Users/macbobbychibuzor/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/tokens/transfer-hook-transfer-switch/anchor/Cargo.toml
+++ b/tokens/transfer-hook-transfer-switch/anchor/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+members = [
+    "programs/*"
+]
+
+[profile.release]
+overflow-checks = true
+lto = "fat"
+codegen-units = 1
+[profile.release.build-override]
+opt-level = 3
+incremental = false
+codegen-units = 1

--- a/tokens/transfer-hook-transfer-switch/anchor/README.md
+++ b/tokens/transfer-hook-transfer-switch/anchor/README.md
@@ -1,0 +1,124 @@
+# Transfer Hook Transfer Switch
+
+This Solana program implements a transfer hook that can be toggled on or off for 
+any token. It allows you to control whether transfers are allowed for a given wallet.
+
+## Features
+
+- Initialize a transfer switch
+- Toggle transfers on/off
+- Transfer hook that checks if transfers are allowed
+
+## Prerequisites
+
+- Rust and Cargo
+- Solana CLI
+- Anchor Framework
+
+## Installation
+
+1. Clone the repository:
+   ```
+   git clone https://github.com/solana-developers/program-examples.git
+   cd program-examples/tokens/transfer-hook-transfer-switch/anchor
+   ```
+
+2. Install dependencies:
+   ```
+   npm install
+   ```
+
+## Building the Program
+
+To build the program, run:
+
+```
+anchor build
+```
+
+## Testing
+
+To run the test suite:
+
+```
+anchor test
+```
+
+## Program Structure
+
+The program consists of three main instructions:
+
+1. `initialize`: Creates and initializes the transfer switch account.
+2. `toggle_transfer`: Toggles the transfer switch on or off.
+3. `transfer_hook`: Checks if transfers are allowed before a token transfer.
+
+## Usage
+
+### Initializing the Transfer Switch
+
+```typescript
+await program.methods
+  .initialize()
+  .accounts({
+    transferSwitch: transferSwitchPda,
+    payer: wallet.publicKey,
+    systemProgram: anchor.web3.SystemProgram.programId,
+  })
+  .rpc();
+```
+
+### Toggling the Transfer Switch
+
+```typescript
+await program.methods
+  .toggleTransfer(true) // or false to disable
+  .accounts({
+    transferSwitch: transferSwitchPda,
+    authority: wallet.publicKey,
+  })
+  .rpc();
+```
+
+### Using the Transfer Hook
+
+```typescript
+await program.methods
+  .transferHook(new anchor.BN(amount))
+  .accounts({
+    transferSwitch: transferSwitchPda,
+    from: fromPublicKey,
+    to: toPublicKey,
+    tokenProgram: anchor.utils.token.TOKEN_PROGRAM_ID,
+  })
+  .rpc();
+```
+
+## Account Structure
+
+The `TransferSwitch` account has the following structure:
+
+```rust
+pub struct TransferSwitch {
+    pub is_enabled: bool,
+    pub authority: Pubkey,
+}
+```
+
+## Error Handling
+
+The program defines a custom error:
+
+```rust
+#[error_code]
+pub enum TransferSwitchError {
+    #[msg("Transfers are currently disabled")]
+    TransfersDisabled,
+}
+```
+
+This error is thrown when a transfer is attempted while the transfer switch is disabled.
+
+## Security Considerations
+
+- The `authority` of the `TransferSwitch` account has the power to toggle transfers on and off. Ensure this authority is properly managed and secured.
+- This program does not implement any access control on who can transfer tokens. It only provides a global on/off switch for all transfers.

--- a/tokens/transfer-hook-transfer-switch/anchor/package.json
+++ b/tokens/transfer-hook-transfer-switch/anchor/package.json
@@ -1,0 +1,19 @@
+{
+  "scripts": {
+    "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
+    "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
+  },
+  "dependencies": {
+    "@project-serum/anchor": "^0.26.0"
+  },
+  "devDependencies": {
+    "chai": "^4.3.4",
+    "mocha": "^9.0.3",
+    "ts-mocha": "^10.0.0",
+    "@types/bn.js": "^5.1.0",
+    "@types/chai": "^4.3.0",
+    "@types/mocha": "^9.0.0",
+    "typescript": "^4.3.5",
+    "prettier": "^2.6.2"
+  }
+}

--- a/tokens/transfer-hook-transfer-switch/anchor/programs/transfer-hook-transfer-switch/Cargo.toml
+++ b/tokens/transfer-hook-transfer-switch/anchor/programs/transfer-hook-transfer-switch/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "transfer-hook-transfer-switch"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "transfer_hook_transfer_switch"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = "0.26.0"
+anchor-spl = "0.26.0"

--- a/tokens/transfer-hook-transfer-switch/anchor/programs/transfer-hook-transfer-switch/Xargo.toml
+++ b/tokens/transfer-hook-transfer-switch/anchor/programs/transfer-hook-transfer-switch/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tokens/transfer-hook-transfer-switch/anchor/programs/transfer-hook-transfer-switch/src/lib.rs
+++ b/tokens/transfer-hook-transfer-switch/anchor/programs/transfer-hook-transfer-switch/src/lib.rs
@@ -1,0 +1,66 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::Token;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod transfer_hook_transfer_switch {
+    use super::*;
+
+    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
+        let transfer_switch = &mut ctx.accounts.transfer_switch;
+        transfer_switch.is_enabled = true;
+        transfer_switch.authority = ctx.accounts.payer.key();
+        Ok(())
+    }
+
+    pub fn toggle_transfer(ctx: Context<ToggleTransfer>, enable: bool) -> Result<()> {
+        let transfer_switch = &mut ctx.accounts.transfer_switch;
+        transfer_switch.is_enabled = enable;
+        Ok(())
+    }
+
+    pub fn transfer_hook(ctx: Context<TransferHook>, _amount: u64) -> Result<()> {
+        let transfer_switch = &ctx.accounts.transfer_switch;
+        require!(transfer_switch.is_enabled, TransferSwitchError::TransfersDisabled);
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize<'info> {
+    #[account(init, payer = payer, space = 8 + 1 + 32)]
+    pub transfer_switch: Account<'info, TransferSwitch>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct ToggleTransfer<'info> {
+    #[account(mut, has_one = authority)]
+    pub transfer_switch: Account<'info, TransferSwitch>,
+    pub authority: Signer<'info>,
+}
+
+#[derive(Accounts)]
+pub struct TransferHook<'info> {
+    pub transfer_switch: Account<'info, TransferSwitch>,
+    /// CHECK: This is not dangerous because we don't read or write from this account
+    pub from: AccountInfo<'info>,
+    /// CHECK: This is not dangerous because we don't read or write from this account
+    pub to: AccountInfo<'info>,
+    pub token_program: Program<'info, Token>,
+}
+
+#[account]
+pub struct TransferSwitch {
+    pub is_enabled: bool,
+    pub authority: Pubkey,
+}
+
+#[error_code]
+pub enum TransferSwitchError {
+    #[msg("Transfers are currently disabled")]
+    TransfersDisabled,
+}

--- a/tokens/transfer-hook-transfer-switch/anchor/tests/transfer-hook-transfer-switch.ts
+++ b/tokens/transfer-hook-transfer-switch/anchor/tests/transfer-hook-transfer-switch.ts
@@ -1,0 +1,91 @@
+import * as anchor from '@project-serum/anchor';
+import { Program } from '@project-serum/anchor';
+import { Keypair, PublicKey } from '@solana/web3.js';
+import { expect } from 'chai';
+import { TransferHookTransferSwitch } from '../target/types/transfer_hook_transfer_switch';
+
+describe('transfer-hook-transfer-switch', () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const program = anchor.workspace.TransferHookTransferSwitch as Program<TransferHookTransferSwitch>;
+
+  const transferSwitchKeypair = Keypair.generate();
+
+  it('Initializes the transfer switch', async () => {
+    await program.methods
+      .initialize()
+      .accounts({
+        transferSwitch: transferSwitchKeypair.publicKey,
+        payer: provider.wallet.publicKey,
+        systemProgram: anchor.web3.SystemProgram.programId,
+      })
+      .signers([transferSwitchKeypair])
+      .rpc();
+
+    const transferSwitch = await program.account.transferSwitch.fetch(transferSwitchKeypair.publicKey);
+    expect(transferSwitch.isEnabled).to.be.true;
+    expect(transferSwitch.authority.toString()).to.equal(provider.wallet.publicKey.toString());
+  });
+
+  it('Toggles the transfer switch', async () => {
+    await program.methods
+      .toggleTransfer(false)
+      .accounts({
+        transferSwitch: transferSwitchKeypair.publicKey,
+        authority: provider.wallet.publicKey,
+      })
+      .rpc();
+
+    let transferSwitch = await program.account.transferSwitch.fetch(transferSwitchKeypair.publicKey);
+    expect(transferSwitch.isEnabled).to.be.false;
+
+    await program.methods
+      .toggleTransfer(true)
+      .accounts({
+        transferSwitch: transferSwitchKeypair.publicKey,
+        authority: provider.wallet.publicKey,
+      })
+      .rpc();
+
+    transferSwitch = await program.account.transferSwitch.fetch(transferSwitchKeypair.publicKey);
+    expect(transferSwitch.isEnabled).to.be.true;
+  });
+
+  it('Allows transfer when enabled', async () => {
+    await program.methods
+      .transferHook(new anchor.BN(100))
+      .accounts({
+        transferSwitch: transferSwitchKeypair.publicKey,
+        from: provider.wallet.publicKey,
+        to: Keypair.generate().publicKey,
+        tokenProgram: anchor.utils.token.TOKEN_PROGRAM_ID,
+      })
+      .rpc();
+  });
+
+  it('Prevents transfer when disabled', async () => {
+    await program.methods
+      .toggleTransfer(false)
+      .accounts({
+        transferSwitch: transferSwitchKeypair.publicKey,
+        authority: provider.wallet.publicKey,
+      })
+      .rpc();
+
+    try {
+      await program.methods
+        .transferHook(new anchor.BN(100))
+        .accounts({
+          transferSwitch: transferSwitchKeypair.publicKey,
+          from: provider.wallet.publicKey,
+          to: Keypair.generate().publicKey,
+          tokenProgram: anchor.utils.token.TOKEN_PROGRAM_ID,
+        })
+        .rpc();
+      expect.fail('The transaction should have failed');
+    } catch (error) {
+      expect(error.message).to.include('Transfers are currently disabled');
+    }
+  });
+});

--- a/tokens/transfer-hook-transfer-switch/anchor/tsconfig.json
+++ b/tokens/transfer-hook-transfer-switch/anchor/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "typeRoots": ["./node_modules/@types", "./target/types"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
- [x] Create Solana program using Anchor for "Transfer hook Transfer Switch: A transfer hook example where transfers for any token can turn on/off for a given wallet."
- [x] Add unit test (run `anchor test` after `anchor build`
- [x] Add` README.md` for explanation.