### PR TITLE
Fix calculations in token-swap anchor example

### DIFF
--- a/tokens/token-swap/anchor/Anchor.toml
+++ b/tokens/token-swap/anchor/Anchor.toml
@@ -4,6 +4,9 @@
 resolution = true
 skip-lint = false
 
+[programs.localnet]
+swap_example = "AsGVFxWqEn8icRBFQApxJe68x3r9zvfSbmiEzYFATGYn"
+
 [programs.devnet]
 swap_example = "AsGVFxWqEn8icRBFQApxJe68x3r9zvfSbmiEzYFATGYn"
 

--- a/tokens/token-swap/anchor/README.md
+++ b/tokens/token-swap/anchor/README.md
@@ -69,8 +69,6 @@ Here are some essential principles to consider when building on-chain programs i
 
 ```file structure
 programs/token-swap/src/
-├── constants.rs
-├── errors.rs
 ├── instructions
 │   ├── create_amm.rs
 │   ├── create_pool.rs
@@ -78,6 +76,8 @@ programs/token-swap/src/
 │   ├── mod.rs
 │   ├── swap_exact_tokens_for_tokens.rs
 │   └── withdraw_liquidity.rs
+├── constants.rs
+├── errors.rs
 ├── lib.rs
 └── state.rs
 ```
@@ -87,15 +87,15 @@ programs/token-swap/src/
 
 This code is entrypoint for a swap example using the **`anchor_lang`** library. The **`anchor_lang`** library provides tools for creating Solana programs using the Anchor framework. The code defines several functions:
 
-(https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/lib.rs#L1-L8)
+(https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/lib.rs#L1-L8)
 
 The above section contains the necessary imports and module declarations for the program. It imports modules from the anchor_lang library and declares local modules for the crate. The pub use instructions::*; re-exports all items from the instructions module so that they can be accessed from outside this module.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/lib.rs#L10-L11
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/lib.rs#L10-L11
 
 This macro declares the program ID and associates it with the given string. This ID should match the deployed Solana program's ID to ensure the correct program is invoked when interacting with the smart contract.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/lib.rs#L13-L45
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/lib.rs#L13-L46
 
 This section defines the program module using the **`#[program]`** attribute. Each function in this module represents an entry point to the smart contract. Each entry point function takes a **`Context`** parameter, which provides essential information for executing the function, such as the accounts involved and the transaction context.
 
@@ -115,17 +115,17 @@ The **`Amm`** struct has three fields:
 2. **`admin`**: The account that has admin authority over the AMM, represented as a **`Pubkey`**.
 3. **`fee`**: The LP fee taken on each trade, represented as a **`u16`** (unsigned 16-bit integer) in basis points.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/state.rs#L1-L14
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/state.rs#L1-L14
 
 
 The above code declares an account structure called Amm. The #[account] attribute indicates that this structure will be used as an account on the Solana blockchain. The #[derive(Default)] attribute automatically generates a default implementation of the struct with all fields set to their default values.
 
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/state.rs#L16-L18
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/state.rs#L16-L18
 
 This code implements a constant LEN for the Amm struct, which represents the size of the Amm account in bytes. The size is calculated by adding the sizes of the individual fields (id, admin, and fee). For example, Pubkey has a fixed size of 32 bytes, and u16 has a size of 2 bytes.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/state.rs#L20-L31
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/state.rs#L20-L31
 
 The code declares another account structure called **`Pool`**. As before, the **`#[account]`** attribute indicates that this struct will be used as an account on the Solana blockchain, and the **`#[derive(Default)]`** attribute generates a default implementation with all fields set to their default values.
 
@@ -135,7 +135,7 @@ The **`Pool`** struct has three fields:
 2. **`mint_a`**: The mint of token A associated with this pool, represented as a **`Pubkey`**.
 3. **`mint_b`**: The mint of token B associated with this pool, represented as a **`Pubkey`**.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/state.rs#L33-L35
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/state.rs#L33-L35
 
 This code implements a constant LEN for the Pool struct, which represents the size of the Pool account in bytes. Similar to the Amm struct, the size is calculated by adding the sizes of the individual fields (amm, mint_a, and mint_b). Each Pubkey has a size of 32 bytes, and the total size is 8 bytes (for padding) + 32 bytes (amm) + 32 bytes (mint_a) + 32 bytes (mint_b) = 104 bytes.
 
@@ -143,7 +143,7 @@ This code implements a constant LEN for the Pool struct, which represents the si
    
    3.1 **create amm**
 
-   https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/create_amm.rs#L1-L12
+   https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/create_amm.rs#L1-L12
 
    The above code defines a function named **`create_amm`** that is used to create an AMM account. It takes four parameters:
 
@@ -157,7 +157,7 @@ The function does the following:
 - It sets the fields of the AMM account with the provided values using **`amm.id = id;`**, **`amm.admin = ctx.accounts.admin.key();`**, and **`amm.fee = fee;`**.
 - It returns **`Ok(())`** to indicate the success of the operation.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/create_amm.rs#L14-L39
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/create_amm.rs#L14-L39
 
 This code defines a struct **`CreateAmm`** using the **`Accounts`** attribute, which serves as the accounts instruction for the **`create_amm`** function.
 
@@ -172,7 +172,7 @@ TLDR-, this code sets up the instruction structure for the **`create_amm`** func
 
   3.2 **create pool**
 
-  https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/create_pool.rs#L1-L20
+  https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/create_pool.rs#L1-L19
 
   The above code defines a function named **`create_pool`** that creates a liquidity pool. It takes a single parameter, **`ctx`**, which represents the **`Context<CreatePool>`** used to execute the function.
 
@@ -182,7 +182,7 @@ The function does the following:
 - It sets the fields of the **`Pool`** account with the keys of the associated accounts using **`pool.amm = ctx.accounts.amm.key();`**, **`pool.mint_a = ctx.accounts.mint_a.key();`**, and **`pool.mint_b = ctx.accounts.mint_b.key();`**.
 - It returns **`Ok(())`** to indicate the success of the operation.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/create_pool.rs#L22-L101
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/create_pool.rs#L21-L99
 
 This code defines a struct named **`CreatePool`**, which serves as the accounts instruction for the **`create_pool`** function.
 
@@ -203,7 +203,7 @@ TLDR, this code defines the accounts instruction structure for the **`create_poo
 
   3.3 **deposite liquidity**
 
-  https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs#L1-L30
+  https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs#L1-L29
 
 The above code defines a function named **`deposit_liquidity`** that allows depositing liquidity into the pool. It takes three parameters:
 
@@ -215,21 +215,21 @@ The function does the following:
 
 - It checks if the depositor has enough tokens for each type (A and B) before depositing and restricts the amounts to the available balances using the **`if`** conditions.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs#L32-L61
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs#L32-L60
 
 This code ensures that the amounts of tokens A and B being deposited are provided in the same proportion as the existing liquidity in the pool. If this is the first deposit (pool creation), the amounts are added as is. Otherwise, the function calculates the ratio of the existing liquidity (pool_a.amount and pool_b.amount) and adjusts the amounts being deposited accordingly.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs#L63-L77
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs#L62-L76
 
 This code calculates the amount of liquidity that is about to be deposited into the pool. It calculates the square root of the product of **`amount_a`** and **`amount_b`**, using fixed-point arithmetic to ensure precision.
 
 If this is the first deposit (pool creation), the function checks if the calculated liquidity is greater than the **`MINIMUM_LIQUIDITY`** constant (a minimum liquidity required for the pool). If it's not, the function returns an error to indicate that the deposit is too small. Additionally, it subtracts the **`MINIMUM_LIQUIDITY`** from the calculated liquidity to lock it as the initial liquidity.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs#L79-L101
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs#L78-L100
 
 This code uses the token::transfer function from the Anchor SPL token crate to transfer the deposited amounts of tokens A and B from the depositor's accounts (depositor_account_a and depositor_account_b, respectively) to the pool's accounts (pool_account_a and pool_account_b, respectively). It does this through cross-program invocation (CPI) using the token program, and the authority for the transfer is the depositor.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs#L102-L124
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs#L102-L123
 
 This code uses the **`token::mint_to`** function from the Anchor SPL token crate to mint the liquidity tokens to the depositor. It does this through cross-program invocation (CPI) using the token program. The minting is authorized by the pool authority (**`pool_authority`**).
 
@@ -239,7 +239,7 @@ TRDR, this code implements the logic to deposit liquidity into the pool, ensurin
 
  3.4 **swap exact tokens**
 
- https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L1-L27
+ https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L1-L27
 
  This code defines a function named **`swap_exact_tokens_for_tokens`** that allows swapping tokens A for tokens B (and vice versa) in the AMM pool. It takes five parameters:
 
@@ -252,55 +252,55 @@ The function does the following:
 
 - It checks if the trader has enough tokens for the input amount of the specified token (**`swap_a`**) before proceeding with the swap. If the trader doesn't have enough tokens, it uses the available amount for the swap.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L29-L31
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L29-L31
 
 This code applies the trading fee to the input amount (input) based on the amm (AMM) account's fee value. The trading fee is subtracted from the input amount to calculate the taxed_input, which is the actual amount of tokens available for the swap after deducting the fee.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L33-L56
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L33-L56
 
 This code calculates the output amount of the swapped token based on the taxed_input, current pool balances (pool_a.amount and pool_b.amount), and whether the swap is from token A to token B or vice versa. It uses fixed-point arithmetic to ensure precise calculations. The resulting output represents the amount of tokens the trader will receive after the swap.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L58-L60
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L58-L60
 
 This code checks if the calculated **`output`** is less than the specified **`min_output_amount`**. If so, it returns an error, indicating that the output amount is too small.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L62-L63
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L62-L63
 
 This code calculates the invariant of the pool, which is the product of the current balances of token A (**`pool_a.amount`**) and token B (**`pool_b.amount`**).
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L65-L123
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L65-L123
 
 This code transfers the input and output amounts of tokens between the trader and the pool, performing the token swap. It uses the **`token::transfer`** function from the Anchor SPL token crate to transfer tokens from one account to another. The **`CpiContext`** is used for Cross-Program Invocation (CPI) to interact with the SPL token program.
 
 The code chooses the appropriate token accounts to perform the transfer based on whether the swap is from token A to token B or vice versa (**`swap_a`**). The transfer authority is specified as either **`trader`** or **`pool_authority`** based on the situation.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L124-L130
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L125-L130
 
 This code logs a message indicating the details of the trade, including the input amount, the taxed input amount, and the output amount.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L132-L141
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs#L132-L141
 
 This code reloads the pool token accounts (pool_account_a and pool_account_b) to get the updated balances after the swap. It then checks if the invariant still holds, ensuring that the product of the balances remains constant. If the invariant is violated, it returns an error.
 Finally, this code returns Ok(()) if all operations in the function executed successfully.
 
  3.5 **withdraw liquidity**
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs#L1-L11
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs#L1-L11
 
 The use statements import required modules and types for the function.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs#L13
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs#L13
 
 This code defines a function named **`withdraw_liquidity`** that allows a liquidity provider to withdraw their liquidity from the AMM pool. It takes two parameters:
 
 1. **`ctx`**: The **`Context<WithdrawLiquidity>`** parameter contains the context data required to execute the function.
 2. **`amount`**: The **`u64`** parameter represents the amount of liquidity tokens the provider wants to withdraw.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs#L14-L22
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs#L14-L22
 
 This code sets up the authority seeds and signer seeds required for performing token transfers and burning the liquidity tokens. The authority seeds include the AMM ID, mint keys of tokens A and B, the authority seed constant, and the authority bump seed. The signer seeds are derived from the authority seeds.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs#L24-L45
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs#L24-L45
 
 This code calculates the amount of token A to be transferred to the liquidity provider by performing the following steps:
 
@@ -308,25 +308,17 @@ This code calculates the amount of token A to be transferred to the liquidity pr
 2. Calculate the proportional amount of token A based on the pool's token A balance (**`ctx.accounts.pool_account_a.amount`**).
 3. Transfer the calculated amount of token A from the pool account to the liquidity provider's account using the **`token::transfer`** function.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs#L47-L67
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs#L47-L67
 
 This code follows the same steps as above but for token B, transferring the calculated amount of token B from the pool account to the liquidity provider's account.
 
-https://github.com/solana-developers/program-examples/blob/419cb6b6c20e8b1c65711b68a4dde2527725cc1a/tokens/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs#L69-L83
+https://github.com/solana-developers/program-examples/blob/main/tokens/token-swap/anchor/programs/token-swap/src/instructions/withdraw_liquidity.rs#L69-L83
 
 This code burns the specified amount of liquidity tokens (amount) by calling the token::burn function. The liquidity tokens are destroyed, reducing the total supply.
 Finally, this code returns Ok(()) if all operations in the function executed successfully. This indicates that the liquidity withdrawal was completed without any errors.
 
-
-
-
-  
-
-
-
-
-
-
-
-
-
+## Run tests
+```bash
+pnpm install
+anchor test
+```

--- a/tokens/token-swap/anchor/package.json
+++ b/tokens/token-swap/anchor/package.json
@@ -4,7 +4,7 @@
     "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
   },
   "dependencies": {
-    "@coral-xyz/anchor": "^0.30.0",
+    "@coral-xyz/anchor": "^0.29.0",
     "@solana/spl-token": "^0.3.8"
   },
   "devDependencies": {

--- a/tokens/token-swap/anchor/pnpm-lock.yaml
+++ b/tokens/token-swap/anchor/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@coral-xyz/anchor':
-        specifier: ^0.30.0
-        version: 0.30.0
+        specifier: ^0.29.0
+        version: 0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@solana/spl-token':
         specifier: ^0.3.8
-        version: 0.3.11(@solana/web3.js@1.91.8)(fastestsmallesttextencoderdecoder@1.0.22)
+        version: 0.3.11(@solana/web3.js@1.91.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -46,12 +46,12 @@ packages:
     resolution: {integrity: sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==}
     engines: {node: '>=6.9.0'}
 
-  '@coral-xyz/anchor@0.30.0':
-    resolution: {integrity: sha512-qreDh5ztiRHVnCbJ+RS70NJ6aSTPBYDAgFeQ7Z5QvaT5DcDIhNyt4onOciVz2ieIE1XWePOJDDu9SbNvPGBkvQ==}
+  '@coral-xyz/anchor@0.29.0':
+    resolution: {integrity: sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==}
     engines: {node: '>=11'}
 
-  '@coral-xyz/borsh@0.30.0':
-    resolution: {integrity: sha512-OrcV+7N10cChhgDRUxM4iEIuwxUHHs52XD85R8cFCUqE0vbLYrcoPPPs+VF6kZ9DhdJGVW2I6DHJOp5TykyZog==}
+  '@coral-xyz/borsh@0.29.0':
+    resolution: {integrity: sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==}
     engines: {node: '>=10'}
     peerDependencies:
       '@solana/web3.js': ^1.68.0
@@ -753,11 +753,11 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@coral-xyz/anchor@0.30.0':
+  '@coral-xyz/anchor@0.29.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
-      '@coral-xyz/borsh': 0.30.0(@solana/web3.js@1.91.8)
+      '@coral-xyz/borsh': 0.29.0(@solana/web3.js@1.91.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@noble/hashes': 1.4.0
-      '@solana/web3.js': 1.91.8
+      '@solana/web3.js': 1.91.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       bn.js: 5.2.1
       bs58: 4.0.1
       buffer-layout: 1.2.2
@@ -774,9 +774,9 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@coral-xyz/borsh@0.30.0(@solana/web3.js@1.91.8)':
+  '@coral-xyz/borsh@0.29.0(@solana/web3.js@1.91.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/web3.js': 1.91.8
+      '@solana/web3.js': 1.91.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       bn.js: 5.2.1
       buffer-layout: 1.2.2
 
@@ -786,10 +786,10 @@ snapshots:
 
   '@noble/hashes@1.4.0': {}
 
-  '@solana/buffer-layout-utils@0.2.0':
+  '@solana/buffer-layout-utils@0.2.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/buffer-layout': 4.0.1
-      '@solana/web3.js': 1.91.8
+      '@solana/web3.js': 1.91.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       bigint-buffer: 1.1.5
       bignumber.js: 9.1.2
     transitivePeerDependencies:
@@ -843,20 +843,20 @@ snapshots:
       '@solana/codecs-core': 2.0.0-preview.2
       '@solana/codecs-numbers': 2.0.0-preview.2
 
-  '@solana/spl-token-metadata@0.1.4(@solana/web3.js@1.91.8)(fastestsmallesttextencoderdecoder@1.0.22)':
+  '@solana/spl-token-metadata@0.1.4(@solana/web3.js@1.91.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)':
     dependencies:
       '@solana/codecs': 2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)
       '@solana/spl-type-length-value': 0.1.0
-      '@solana/web3.js': 1.91.8
+      '@solana/web3.js': 1.91.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/spl-token@0.3.11(@solana/web3.js@1.91.8)(fastestsmallesttextencoderdecoder@1.0.22)':
+  '@solana/spl-token@0.3.11(@solana/web3.js@1.91.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(bufferutil@4.0.8)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/buffer-layout': 4.0.1
-      '@solana/buffer-layout-utils': 0.2.0
-      '@solana/spl-token-metadata': 0.1.4(@solana/web3.js@1.91.8)(fastestsmallesttextencoderdecoder@1.0.22)
-      '@solana/web3.js': 1.91.8
+      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@solana/spl-token-metadata': 0.1.4(@solana/web3.js@1.91.8(bufferutil@4.0.8)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/web3.js': 1.91.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       buffer: 6.0.3
     transitivePeerDependencies:
       - bufferutil
@@ -868,7 +868,7 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@solana/web3.js@1.91.8':
+  '@solana/web3.js@1.91.8(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/runtime': 7.24.5
       '@noble/curves': 1.4.0
@@ -881,7 +881,7 @@ snapshots:
       bs58: 4.0.1
       buffer: 6.0.3
       fast-stable-stringify: 1.0.0
-      jayson: 4.1.0
+      jayson: 4.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       node-fetch: 2.7.0
       rpc-websockets: 7.11.0
       superstruct: 0.14.2
@@ -1000,6 +1000,7 @@ snapshots:
   bufferutil@4.0.8:
     dependencies:
       node-gyp-build: 4.8.1
+    optional: true
 
   camelcase@6.3.0: {}
 
@@ -1065,6 +1066,7 @@ snapshots:
   debug@4.3.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
       supports-color: 8.1.1
 
   decamelize@4.0.0: {}
@@ -1178,11 +1180,11 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isomorphic-ws@4.0.1(ws@7.5.9):
+  isomorphic-ws@4.0.1(ws@7.5.9(bufferutil@4.0.8)(utf-8-validate@5.0.10)):
     dependencies:
-      ws: 7.5.9
+      ws: 7.5.9(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
-  jayson@4.1.0:
+  jayson@4.1.0(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
       '@types/connect': 3.4.38
       '@types/node': 12.20.55
@@ -1192,10 +1194,10 @@ snapshots:
       delay: 5.0.0
       es6-promisify: 5.0.0
       eyes: 0.1.8
-      isomorphic-ws: 4.0.1(ws@7.5.9)
+      isomorphic-ws: 4.0.1(ws@7.5.9(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       json-stringify-safe: 5.0.1
       uuid: 8.3.2
-      ws: 7.5.9
+      ws: 7.5.9(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -1288,7 +1290,8 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-gyp-build@4.8.1: {}
+  node-gyp-build@4.8.1:
+    optional: true
 
   normalize-path@3.0.0: {}
 
@@ -1431,6 +1434,7 @@ snapshots:
   utf-8-validate@5.0.10:
     dependencies:
       node-gyp-build: 4.8.1
+    optional: true
 
   uuid@8.3.2: {}
 
@@ -1455,10 +1459,13 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@7.5.9: {}
+  ws@7.5.9(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.8
+      utf-8-validate: 5.0.10
 
   ws@8.17.0(bufferutil@4.0.8)(utf-8-validate@5.0.10):
-    dependencies:
+    optionalDependencies:
       bufferutil: 4.0.8
       utf-8-validate: 5.0.10
 

--- a/tokens/token-swap/anchor/programs/token-swap/Cargo.toml
+++ b/tokens/token-swap/anchor/programs/token-swap/Cargo.toml
@@ -17,6 +17,6 @@ no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 
 [dependencies]
-anchor-lang = { version = "0.30.0", features = ["init-if-needed"] }
-anchor-spl = { version = "0.30.0", features = ["metadata"] }
+anchor-lang = { version = "0.29.0", features = ["init-if-needed"] }
+anchor-spl = { version = "0.29.0", features = ["metadata"] }
 fixed = "1.27.0"

--- a/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
@@ -16,7 +16,7 @@ pub fn deposit_liquidity(
     amount_a: u64,
     amount_b: u64,
 ) -> Result<()> {
-    // Prevent depositing assets the depositor does not own
+    // If the user specified amounts greater than held, use the total amounts they do have
     let mut amount_a = if amount_a > ctx.accounts.depositor_account_a.amount {
         ctx.accounts.depositor_account_a.amount
     } else {
@@ -38,7 +38,7 @@ pub fn deposit_liquidity(
         (amount_a, amount_b)
     } else {
         let ratio = I64F64::from_num(pool_a.amount)
-            .checked_mul(I64F64::from_num(pool_b.amount))
+            .checked_div(I64F64::from_num(pool_b.amount))
             .unwrap();
         if pool_a.amount > pool_b.amount {
             (

--- a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs
@@ -17,7 +17,7 @@ pub fn swap_exact_tokens_for_tokens(
     input_amount: u64,
     min_output_amount: u64,
 ) -> Result<()> {
-    // Prevent depositing assets the depositor does not own
+    // If the user specified amounts greater than held, use the total amounts they do have
     let input = if swap_a && input_amount > ctx.accounts.trader_account_a.amount {
         ctx.accounts.trader_account_a.amount
     } else if !swap_a && input_amount > ctx.accounts.trader_account_b.amount {
@@ -134,7 +134,7 @@ pub fn swap_exact_tokens_for_tokens(
     // We tolerate if the new invariant is higher because it means a rounding error for LPs
     ctx.accounts.pool_account_a.reload()?;
     ctx.accounts.pool_account_b.reload()?;
-    if invariant > ctx.accounts.pool_account_a.amount * ctx.accounts.pool_account_a.amount {
+    if invariant > ctx.accounts.pool_account_a.amount * ctx.accounts.pool_account_b.amount {
         return err!(TutorialError::InvariantViolated);
     }
 

--- a/tokens/token-swap/anchor/tests/create-amm.ts
+++ b/tokens/token-swap/anchor/tests/create-amm.ts
@@ -6,7 +6,6 @@ import { type TestValues, createValues, expectRevert } from './utils';
 
 describe('Create AMM', () => {
   const provider = anchor.AnchorProvider.env();
-  const connection = provider.connection;
   anchor.setProvider(provider);
 
   const program = anchor.workspace.SwapExample as Program<SwapExample>;

--- a/tokens/token-swap/anchor/tests/deposit-liquidity.ts
+++ b/tokens/token-swap/anchor/tests/deposit-liquidity.ts
@@ -3,6 +3,7 @@ import type { Program } from '@coral-xyz/anchor';
 import { expect } from 'chai';
 import type { SwapExample } from '../target/types/swap_example';
 import { type TestValues, createValues, mintingTokens } from './utils';
+import { BN } from 'bn.js';
 
 describe('Deposit liquidity', () => {
   const provider = anchor.AnchorProvider.env();
@@ -40,7 +41,7 @@ describe('Deposit liquidity', () => {
       .rpc();
   });
 
-  it('Deposit equal amounts', async () => {
+  it('Deposit equal amounts, twice', async () => {
     await program.methods
       .depositLiquidity(values.depositAmountA, values.depositAmountA)
       .accounts({
@@ -59,11 +60,169 @@ describe('Deposit liquidity', () => {
       .signers([values.admin])
       .rpc({ skipPreflight: true });
 
-    const depositTokenAccountLiquditiy = await connection.getTokenAccountBalance(values.liquidityAccount);
-    expect(depositTokenAccountLiquditiy.value.amount).to.equal(values.depositAmountA.sub(values.minimumLiquidity).toString());
+    const depositTokenAccountLiquidity = await connection.getTokenAccountBalance(values.liquidityAccount);
+    expect(depositTokenAccountLiquidity.value.amount).to.equal(values.depositAmountA.sub(values.minimumLiquidity).toString());
     const depositTokenAccountA = await connection.getTokenAccountBalance(values.holderAccountA);
-    expect(depositTokenAccountA.value.amount).to.equal(values.defaultSupply.sub(values.depositAmountA).toString());
+    expect(depositTokenAccountA.value.amount).to.equal(values.defaultHolderAccountSupply.sub(values.depositAmountA).toString());
     const depositTokenAccountB = await connection.getTokenAccountBalance(values.holderAccountB);
-    expect(depositTokenAccountB.value.amount).to.equal(values.defaultSupply.sub(values.depositAmountA).toString());
+    expect(depositTokenAccountB.value.amount).to.equal(values.defaultHolderAccountSupply.sub(values.depositAmountA).toString());
+    
+    await program.methods
+      .depositLiquidity(values.depositAmountB, values.depositAmountB)
+      .accounts({
+        pool: values.poolKey,
+        poolAuthority: values.poolAuthority,
+        depositor: values.admin.publicKey,
+        mintLiquidity: values.mintLiquidity,
+        mintA: values.mintAKeypair.publicKey,
+        mintB: values.mintBKeypair.publicKey,
+        poolAccountA: values.poolAccountA,
+        poolAccountB: values.poolAccountB,
+        depositorAccountLiquidity: values.liquidityAccount,
+        depositorAccountA: values.holderAccountA,
+        depositorAccountB: values.holderAccountB,
+      })
+      .signers([values.admin])
+      .rpc({ skipPreflight: true });
+
+    const depositTokenAccountLiquidity2 = await connection.getTokenAccountBalance(values.liquidityAccount);
+    // No minimumLiquidity subtraction since it's not the first deposit
+    expect(depositTokenAccountLiquidity2.value.amount).to.equal(new BN(depositTokenAccountLiquidity.value.amount)
+                                                                .add(values.depositAmountB).toString());
+    const depositTokenAccountA2 = await connection.getTokenAccountBalance(values.holderAccountA);
+    expect(depositTokenAccountA2.value.amount).to.equal(new BN(depositTokenAccountA.value.amount)
+                                                        .sub(values.depositAmountB).toString());
+    const depositTokenAccountB2 = await connection.getTokenAccountBalance(values.holderAccountB);
+    expect(depositTokenAccountB2.value.amount).to.equal(new BN(depositTokenAccountB.value.amount)
+                                                        .sub(values.depositAmountB).toString());
   });
+
+  
+  it('Deposit amounts a > b, then a < b', async () => {
+    var depositAmountA = new BN(9 * 10 ** 6)
+    var depositAmountB = new BN(4 * 10 ** 6)
+    await program.methods
+      .depositLiquidity(depositAmountA, depositAmountB)
+      .accounts({
+        pool: values.poolKey,
+        poolAuthority: values.poolAuthority,
+        depositor: values.admin.publicKey,
+        mintLiquidity: values.mintLiquidity,
+        mintA: values.mintAKeypair.publicKey,
+        mintB: values.mintBKeypair.publicKey,
+        poolAccountA: values.poolAccountA,
+        poolAccountB: values.poolAccountB,
+        depositorAccountLiquidity: values.liquidityAccount,
+        depositorAccountA: values.holderAccountA,
+        depositorAccountB: values.holderAccountB,
+      })
+      .signers([values.admin])
+      .rpc({ skipPreflight: true });
+
+    const depositTokenAccountLiquidity = await connection.getTokenAccountBalance(values.liquidityAccount);
+    expect(depositTokenAccountLiquidity.value.amount).to.equal(new BN(6 * 10 ** 6)
+                                                              .sub(values.minimumLiquidity).toString());
+    const depositTokenAccountA = await connection.getTokenAccountBalance(values.holderAccountA);
+    expect(depositTokenAccountA.value.amount).to.equal(values.defaultHolderAccountSupply.sub(depositAmountA).toString());
+    const depositTokenAccountB = await connection.getTokenAccountBalance(values.holderAccountB);
+    expect(depositTokenAccountB.value.amount).to.equal(values.defaultHolderAccountSupply.sub(depositAmountB).toString());
+
+    // Expected behavior is that depositAmountA gets increased to
+    // (27 * 10 ** 6) * (9/4) = 60.75 * 10 ** 6
+    // to maintain the ratio established in the above deposit
+    depositAmountA = new BN(18 * 10 ** 6)
+    depositAmountB = new BN(27 * 10 ** 6)
+    await program.methods
+      .depositLiquidity(depositAmountA, depositAmountB)
+      .accounts({
+        pool: values.poolKey,
+        poolAuthority: values.poolAuthority,
+        depositor: values.admin.publicKey,
+        mintLiquidity: values.mintLiquidity,
+        mintA: values.mintAKeypair.publicKey,
+        mintB: values.mintBKeypair.publicKey,
+        poolAccountA: values.poolAccountA,
+        poolAccountB: values.poolAccountB,
+        depositorAccountLiquidity: values.liquidityAccount,
+        depositorAccountA: values.holderAccountA,
+        depositorAccountB: values.holderAccountB,
+      })
+      .signers([values.admin])
+      .rpc({ skipPreflight: true });
+
+    const depositTokenAccountLiquidity2 = await connection.getTokenAccountBalance(values.liquidityAccount);
+    expect(depositTokenAccountLiquidity2.value.amount).to.equal(new BN(40.5 * 10 ** 6)
+                                                                .add(new BN(depositTokenAccountLiquidity.value.amount))
+                                                                .toString());
+    const depositTokenAccountA2 = await connection.getTokenAccountBalance(values.holderAccountA);
+    expect(depositTokenAccountA2.value.amount).to.equal(new BN (depositTokenAccountA.value.amount)
+                                                        .sub(new BN(60.75 * 10 ** 6)).toString());
+    const depositTokenAccountB2 = await connection.getTokenAccountBalance(values.holderAccountB);
+    expect(depositTokenAccountB2.value.amount).to.equal(new BN (depositTokenAccountB.value.amount)
+                                                        .sub(depositAmountB).toString());
+  });
+
+  it('Deposit amounts a < b, then a > b', async () => {
+    var depositAmountA = new BN(4 * 10 ** 6)
+    var depositAmountB = new BN(9 * 10 ** 6)
+    await program.methods
+      .depositLiquidity(depositAmountA, depositAmountB)
+      .accounts({
+        pool: values.poolKey,
+        poolAuthority: values.poolAuthority,
+        depositor: values.admin.publicKey,
+        mintLiquidity: values.mintLiquidity,
+        mintA: values.mintAKeypair.publicKey,
+        mintB: values.mintBKeypair.publicKey,
+        poolAccountA: values.poolAccountA,
+        poolAccountB: values.poolAccountB,
+        depositorAccountLiquidity: values.liquidityAccount,
+        depositorAccountA: values.holderAccountA,
+        depositorAccountB: values.holderAccountB,
+      })
+      .signers([values.admin])
+      .rpc({ skipPreflight: true });
+
+    const depositTokenAccountLiquidity = await connection.getTokenAccountBalance(values.liquidityAccount);
+    expect(depositTokenAccountLiquidity.value.amount).to.equal(new BN(6 * 10 ** 6)
+                                                              .sub(values.minimumLiquidity).toString());
+    const depositTokenAccountA = await connection.getTokenAccountBalance(values.holderAccountA);
+    expect(depositTokenAccountA.value.amount).to.equal(values.defaultHolderAccountSupply.sub(depositAmountA).toString());
+    const depositTokenAccountB = await connection.getTokenAccountBalance(values.holderAccountB);
+    expect(depositTokenAccountB.value.amount).to.equal(values.defaultHolderAccountSupply.sub(depositAmountB).toString());
+    
+    // Expected behavior is that depositAmountB gets increased to
+    // (27 * 10 ** 6) * (9/4) = 60.75 * 10 ** 6
+    // to maintain the ratio established in the above deposit
+    depositAmountA = new BN(27 * 10 ** 6)
+    depositAmountB = new BN(18 * 10 ** 6)
+    await program.methods
+      .depositLiquidity(depositAmountA, depositAmountB)
+      .accounts({
+        pool: values.poolKey,
+        poolAuthority: values.poolAuthority,
+        depositor: values.admin.publicKey,
+        mintLiquidity: values.mintLiquidity,
+        mintA: values.mintAKeypair.publicKey,
+        mintB: values.mintBKeypair.publicKey,
+        poolAccountA: values.poolAccountA,
+        poolAccountB: values.poolAccountB,
+        depositorAccountLiquidity: values.liquidityAccount,
+        depositorAccountA: values.holderAccountA,
+        depositorAccountB: values.holderAccountB,
+      })
+      .signers([values.admin])
+      .rpc({ skipPreflight: true });
+
+    const depositTokenAccountLiquidity2 = await connection.getTokenAccountBalance(values.liquidityAccount);
+    expect(depositTokenAccountLiquidity2.value.amount).to.equal(new BN(40.5 * 10 ** 6)
+                                                                .add(new BN(depositTokenAccountLiquidity.value.amount))
+                                                                .toString());
+    const depositTokenAccountA2 = await connection.getTokenAccountBalance(values.holderAccountA);
+    expect(depositTokenAccountA2.value.amount).to.equal(new BN (depositTokenAccountA.value.amount)
+                                                        .sub(depositAmountA).toString());
+    const depositTokenAccountB2 = await connection.getTokenAccountBalance(values.holderAccountB);
+    expect(depositTokenAccountB2.value.amount).to.equal(new BN (depositTokenAccountB.value.amount)
+                                                        .sub(new BN(60.75 * 10 ** 6)).toString());
+    })
 });

--- a/tokens/token-swap/anchor/tests/swap.ts
+++ b/tokens/token-swap/anchor/tests/swap.ts
@@ -80,8 +80,8 @@ describe('Swap', () => {
 
     const traderTokenAccountA = await connection.getTokenAccountBalance(values.holderAccountA);
     const traderTokenAccountB = await connection.getTokenAccountBalance(values.holderAccountB);
-    expect(traderTokenAccountA.value.amount).to.equal(values.defaultSupply.sub(values.depositAmountA).sub(input).toString());
-    expect(Number(traderTokenAccountB.value.amount)).to.be.greaterThan(values.defaultSupply.sub(values.depositAmountB).toNumber());
-    expect(Number(traderTokenAccountB.value.amount)).to.be.lessThan(values.defaultSupply.sub(values.depositAmountB).add(input).toNumber());
+    expect(traderTokenAccountA.value.amount).to.equal(values.defaultHolderAccountSupply.sub(values.depositAmountA).sub(input).toString());
+    expect(Number(traderTokenAccountB.value.amount)).to.be.greaterThan(values.defaultHolderAccountSupply.sub(values.depositAmountB).toNumber());
+    expect(Number(traderTokenAccountB.value.amount)).to.be.lessThan(values.defaultHolderAccountSupply.sub(values.depositAmountB).add(input).toNumber());
   });
 });

--- a/tokens/token-swap/anchor/tests/swap.ts
+++ b/tokens/token-swap/anchor/tests/swap.ts
@@ -40,6 +40,9 @@ describe('Swap', () => {
       })
       .rpc();
 
+  });
+
+  it('Swap from a to b, initial deposit a > b', async () => {
     await program.methods
       .depositLiquidity(values.depositAmountA, values.depositAmountB)
       .accounts({
@@ -57,9 +60,6 @@ describe('Swap', () => {
       })
       .signers([values.admin])
       .rpc({ skipPreflight: true });
-  });
-
-  it('Swap from A to B', async () => {
     const input = new BN(10 ** 6);
     await program.methods
       .swapExactTokensForTokens(true, input, new BN(100))
@@ -80,8 +80,61 @@ describe('Swap', () => {
 
     const traderTokenAccountA = await connection.getTokenAccountBalance(values.holderAccountA);
     const traderTokenAccountB = await connection.getTokenAccountBalance(values.holderAccountB);
-    expect(traderTokenAccountA.value.amount).to.equal(values.defaultHolderAccountSupply.sub(values.depositAmountA).sub(input).toString());
-    expect(Number(traderTokenAccountB.value.amount)).to.be.greaterThan(values.defaultHolderAccountSupply.sub(values.depositAmountB).toNumber());
-    expect(Number(traderTokenAccountB.value.amount)).to.be.lessThan(values.defaultHolderAccountSupply.sub(values.depositAmountB).add(input).toNumber());
+    expect(traderTokenAccountA.value.amount).to.equal(values.defaultHolderAccountSupply
+                                                      .sub(values.depositAmountA)
+                                                      .sub(input).toString());
+    expect(Number(traderTokenAccountB.value.amount)).to.be.greaterThan(values.defaultHolderAccountSupply
+                                                                      .sub(values.depositAmountB).toNumber());
+    expect(Number(traderTokenAccountB.value.amount)).to.be.lessThan(values.defaultHolderAccountSupply
+                                                                    .sub(values.depositAmountB)
+                                                                    .add(input).toNumber());
+  });
+  
+  it('Swap from a to b, initial deposit a < b', async () => {
+    const depositAmountA = new BN(10 * 10 ** 6)
+    const depositAmountB = new BN(30 * 10 ** 6)
+    await program.methods
+      .depositLiquidity(depositAmountA, depositAmountB)
+      .accounts({
+        pool: values.poolKey,
+        poolAuthority: values.poolAuthority,
+        depositor: values.admin.publicKey,
+        mintLiquidity: values.mintLiquidity,
+        mintA: values.mintAKeypair.publicKey,
+        mintB: values.mintBKeypair.publicKey,
+        poolAccountA: values.poolAccountA,
+        poolAccountB: values.poolAccountB,
+        depositorAccountLiquidity: values.liquidityAccount,
+        depositorAccountA: values.holderAccountA,
+        depositorAccountB: values.holderAccountB,
+      })
+      .signers([values.admin])
+      .rpc({ skipPreflight: true });
+    const input = new BN(10 ** 6);
+    await program.methods
+      .swapExactTokensForTokens(true, input, new BN(100))
+      .accounts({
+        amm: values.ammKey,
+        pool: values.poolKey,
+        poolAuthority: values.poolAuthority,
+        trader: values.admin.publicKey,
+        mintA: values.mintAKeypair.publicKey,
+        mintB: values.mintBKeypair.publicKey,
+        poolAccountA: values.poolAccountA,
+        poolAccountB: values.poolAccountB,
+        traderAccountA: values.holderAccountA,
+        traderAccountB: values.holderAccountB,
+      })
+      .signers([values.admin])
+      .rpc({ skipPreflight: true });
+
+    const traderTokenAccountA = await connection.getTokenAccountBalance(values.holderAccountA);
+    const traderTokenAccountB = await connection.getTokenAccountBalance(values.holderAccountB);
+    expect(traderTokenAccountA.value.amount).to.equal(values.defaultHolderAccountSupply
+                                                      .sub(depositAmountA)
+                                                      .sub(input).toString());
+    expect(Number(traderTokenAccountB.value.amount)).to.be.greaterThan(values.defaultHolderAccountSupply
+                                                                    .sub(depositAmountB)
+                                                                    .add(input).toNumber());
   });
 });

--- a/tokens/token-swap/anchor/tests/utils.ts
+++ b/tokens/token-swap/anchor/tests/utils.ts
@@ -20,14 +20,16 @@ export const expectRevert = async (promise: Promise<any>) => {
   }
 };
 
+const defaultMintedAmount = 100
+const defaultDecimals = 6
 export const mintingTokens = async ({
   connection,
   creator,
   holder = creator,
   mintAKeypair,
   mintBKeypair,
-  mintedAmount = 100,
-  decimals = 6,
+  mintedAmount = defaultMintedAmount,
+  decimals = defaultDecimals,
 }: {
   connection: Connection;
   creator: Signer;
@@ -67,7 +69,7 @@ export interface TestValues {
   admin: Keypair;
   mintAKeypair: Keypair;
   mintBKeypair: Keypair;
-  defaultSupply: anchor.BN;
+  defaultHolderAccountSupply: anchor.BN;
   ammKey: PublicKey;
   minimumLiquidity: anchor.BN;
   poolKey: PublicKey;
@@ -127,6 +129,6 @@ export function createValues(defaults?: TestValuesDefaults): TestValues {
     depositAmountA: new BN(4 * 10 ** 6),
     depositAmountB: new BN(1 * 10 ** 6),
     minimumLiquidity: new BN(100),
-    defaultSupply: new BN(100 * 10 ** 6),
+    defaultHolderAccountSupply: new BN(defaultMintedAmount * 10 ** defaultDecimals),
   };
 }

--- a/tokens/token-swap/anchor/tests/withdraw-liquidity.ts
+++ b/tokens/token-swap/anchor/tests/withdraw-liquidity.ts
@@ -82,9 +82,9 @@ describe('Withdraw liquidity', () => {
     const depositTokenAccountA = await connection.getTokenAccountBalance(values.holderAccountA);
     const depositTokenAccountB = await connection.getTokenAccountBalance(values.holderAccountB);
     expect(liquidityTokenAccount.value.amount).to.equal('0');
-    expect(Number(depositTokenAccountA.value.amount)).to.be.lessThan(values.defaultSupply.toNumber());
-    expect(Number(depositTokenAccountA.value.amount)).to.be.greaterThan(values.defaultSupply.sub(values.depositAmountA).toNumber());
-    expect(Number(depositTokenAccountB.value.amount)).to.be.lessThan(values.defaultSupply.toNumber());
-    expect(Number(depositTokenAccountB.value.amount)).to.be.greaterThan(values.defaultSupply.sub(values.depositAmountA).toNumber());
+    expect(Number(depositTokenAccountA.value.amount)).to.be.lessThan(values.defaultHolderAccountSupply.toNumber());
+    expect(Number(depositTokenAccountA.value.amount)).to.be.greaterThan(values.defaultHolderAccountSupply.sub(values.depositAmountA).toNumber());
+    expect(Number(depositTokenAccountB.value.amount)).to.be.lessThan(values.defaultHolderAccountSupply.toNumber());
+    expect(Number(depositTokenAccountB.value.amount)).to.be.greaterThan(values.defaultHolderAccountSupply.sub(values.depositAmountA).toNumber());
   });
 });


### PR DESCRIPTION
* Fix liquidity ratio calculation in deposit and add tests
Liquidity pool ratio was being calculated by multiplying token supplies instead of dividing causing incorrect amounts of attempted deposits and liquidity token mints. This bug wasn't caught by tests because the ratio is only used on deposits subsequent to the initial deposit and the tests previously only covered the initial deposit.

* Fix invariant validation calculation in swap and add tests
A suspected typo in the invariant calculation used for validation in `swap_exact_tokens_for_tokens.rs` would cause the program to fail even if the swap should otherwise be successful. This bug wasn't caught by tests because they did not cover the case when initial deposit contains amounts where a < b, which is the case when the failure occurs.

* Anchor version
Using anchor 0.30.0 gave me this error which is why this PR has 0.29.0.
```
**error****: custom attribute panicked**                                                                                   
  **-->** programs/token-swap/src/lib.rs:13:1                                                                            
   **|** **13** **|** #[program]                                                                                                      
   **|** **^^^^^^^^^^**                                                                                                      
   **|**                                                                                                                 
   **=** **help**: message: Safety checks failed: Failed to get program path
```
(Upgrading to anchor 0.30.1 also gives the same error but with a help message of `**help**: message: compiler/fallback mismatch #949`). I couldn't figure this out in a reasonable amount of time. If someone knows how to resolve this that would be great. If it's imperative that we use 0.30, I can try to spend more time on it.