### PR TITLE
close-account native: reduce target account balance to 0

### DIFF
--- a/basics/close-account/native/program/src/instructions/close_user.rs
+++ b/basics/close-account/native/program/src/instructions/close_user.rs
@@ -1,8 +1,5 @@
 use solana_program::{
-    account_info::{next_account_info, AccountInfo},
-    entrypoint::ProgramResult,
-    rent::Rent,
-    sysvar::Sysvar,
+    account_info::{next_account_info, AccountInfo}, entrypoint::ProgramResult
 };
 
 pub fn close_user(accounts: &[AccountInfo]) -> ProgramResult {
@@ -11,17 +8,12 @@ pub fn close_user(accounts: &[AccountInfo]) -> ProgramResult {
     let payer = next_account_info(accounts_iter)?;
     let system_program = next_account_info(accounts_iter)?;
 
-    let account_span = 0usize;
-    let lamports_required = (Rent::get()?).minimum_balance(account_span);
-
-    let diff = target_account.lamports() - lamports_required;
-
     // Send the rent back to the payer
-    **target_account.lamports.borrow_mut() -= diff;
-    **payer.lamports.borrow_mut() += diff;
+    **payer.lamports.borrow_mut() += target_account.lamports();
+    **target_account.lamports.borrow_mut() = 0;
 
     // Realloc the account to zero
-    target_account.realloc(account_span, true)?;
+    target_account.realloc(0usize, true)?;
 
     // Assign the account to the System Program
     target_account.assign(system_program.key);

--- a/basics/close-account/native/tests/close-account.test.ts
+++ b/basics/close-account/native/tests/close-account.test.ts
@@ -1,5 +1,6 @@
 import { describe, test } from 'node:test';
 import { PublicKey, Transaction } from '@solana/web3.js';
+import { expect } from 'chai';
 import { start } from 'solana-bankrun';
 import { createCloseUserInstruction, createCreateUserInstruction } from '../ts';
 
@@ -30,6 +31,14 @@ describe('Close Account!', async () => {
     tx.recentBlockhash = blockhash;
     tx.add(ix).sign(payer);
 
+    const testAccountInitialBalance = Number(await client.getBalance(testAccountPublicKey));
+    const payerInitialBalance = Number(await client.getBalance(payer.publicKey));
     await client.processTransaction(tx);
+    const payerFinalBalance = Number(await client.getBalance(payer.publicKey));
+    const testAccountFinalBalance = Number(await client.getBalance(testAccountPublicKey));
+
+    expect(payerFinalBalance).to.be.greaterThan(payerInitialBalance); // Assumes rent was > tx fee
+    expect(testAccountInitialBalance).to.be.greaterThan(0);
+    expect(testAccountFinalBalance).to.equal(0);
   });
 });


### PR DESCRIPTION
If I understand correctly, closing an account involves reducing the balance to exactly zero. The native close-account example currently reduces it to a non-zero amount--calculating the remaining rent after reducing the data_len to zero and reducing the balance by _that_ amount, returning it to the payer. This PR reduces it to exactly zero and adds relevant tests.