### PR TITLE
fix: add ANCHOR_DISCRIMINATOR_SIZE to init space

### DIFF
--- a/basics/close-account/anchor/programs/close-account/src/instructions/create_user.rs
+++ b/basics/close-account/anchor/programs/close-account/src/instructions/create_user.rs
@@ -9,7 +9,7 @@ pub struct CreateUserContext<'info> {
     #[account(
         init,
         payer = user,
-        space = UserState::INIT_SPACE,
+        space = 8 + UserState::INIT_SPACE,
         seeds = [
             b"USER",
             user.key().as_ref(),


### PR DESCRIPTION
When the create_user function is called with a name size of `50`(max_len), the error `AccountDidNotSerialize` will be thrown.