### PR TITLE
Fixes to native program example on CPI

### DIFF
--- a/basics/cross-program-invocation/native/package.json
+++ b/basics/cross-program-invocation/native/package.json
@@ -9,7 +9,8 @@
     "@solana/web3.js": "^1.47.3",
     "borsh": "^0.7.0",
     "buffer": "^6.0.3",
-    "fs": "^0.0.1-security"
+    "fs": "^0.0.1-security",
+    "solana-bankrun": "^0.4.0"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",

--- a/basics/cross-program-invocation/native/pnpm-lock.yaml
+++ b/basics/cross-program-invocation/native/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       fs:
         specifier: ^0.0.1-security
         version: 0.0.1-security
+      solana-bankrun:
+        specifier: ^0.4.0
+        version: 0.4.0(bufferutil@4.0.9)(typescript@4.9.5)(utf-8-validate@5.0.10)
     devDependencies:
       '@types/bn.js':
         specifier: ^5.1.0
@@ -511,6 +514,39 @@ packages:
 
   serialize-javascript@6.0.0:
     resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
+
+  solana-bankrun-darwin-arm64@0.4.0:
+    resolution: {integrity: sha512-6dz78Teoz7ez/3lpRLDjktYLJb79FcmJk2me4/YaB8WiO6W43OdExU4h+d2FyuAryO2DgBPXaBoBNY/8J1HJmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  solana-bankrun-darwin-universal@0.4.0:
+    resolution: {integrity: sha512-zSSw/Jx3KNU42pPMmrEWABd0nOwGJfsj7nm9chVZ3ae7WQg3Uty0hHAkn5NSDCj3OOiN0py9Dr1l9vmRJpOOxg==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  solana-bankrun-darwin-x64@0.4.0:
+    resolution: {integrity: sha512-LWjs5fsgHFtyr7YdJR6r0Ho5zrtzI6CY4wvwPXr8H2m3b4pZe6RLIZjQtabCav4cguc14G0K8yQB2PTMuGub8w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  solana-bankrun-linux-x64-gnu@0.4.0:
+    resolution: {integrity: sha512-SrlVrb82UIxt21Zr/XZFHVV/h9zd2/nP25PMpLJVLD7Pgl2yhkhfi82xj3OjxoQqWe+zkBJ+uszA0EEKr67yNw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  solana-bankrun-linux-x64-musl@0.4.0:
+    resolution: {integrity: sha512-Nv328ZanmURdYfcLL+jwB1oMzX4ZzK57NwIcuJjGlf0XSNLq96EoaO5buEiUTo4Ls7MqqMyLbClHcrPE7/aKyA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  solana-bankrun@0.4.0:
+    resolution: {integrity: sha512-NMmXUipPBkt8NgnyNO3SCnPERP6xT/AMNMBooljGA3+rG6NN8lmXJsKeLqQTiFsDeWD74U++QM/DgcueSWvrIg==}
+    engines: {node: '>= 10'}
 
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
@@ -1144,6 +1180,37 @@ snapshots:
   serialize-javascript@6.0.0:
     dependencies:
       randombytes: 2.1.0
+
+  solana-bankrun-darwin-arm64@0.4.0:
+    optional: true
+
+  solana-bankrun-darwin-universal@0.4.0:
+    optional: true
+
+  solana-bankrun-darwin-x64@0.4.0:
+    optional: true
+
+  solana-bankrun-linux-x64-gnu@0.4.0:
+    optional: true
+
+  solana-bankrun-linux-x64-musl@0.4.0:
+    optional: true
+
+  solana-bankrun@0.4.0(bufferutil@4.0.9)(typescript@4.9.5)(utf-8-validate@5.0.10):
+    dependencies:
+      '@solana/web3.js': 1.98.2(bufferutil@4.0.9)(typescript@4.9.5)(utf-8-validate@5.0.10)
+      bs58: 4.0.1
+    optionalDependencies:
+      solana-bankrun-darwin-arm64: 0.4.0
+      solana-bankrun-darwin-universal: 0.4.0
+      solana-bankrun-darwin-x64: 0.4.0
+      solana-bankrun-linux-x64-gnu: 0.4.0
+      solana-bankrun-linux-x64-musl: 0.4.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
 
   source-map-support@0.5.21:
     dependencies:

--- a/basics/cross-program-invocation/native/programs/hand/Cargo.toml
+++ b/basics/cross-program-invocation/native/programs/hand/Cargo.toml
@@ -8,8 +8,7 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-borsh = "0.10"
-borsh-derive = "0.10"
+borsh = "1.5.7"
 solana-program = "2.0"
 cross-program-invocatio-native-lever = { path = "../lever", features = ["cpi"] }
 

--- a/basics/cross-program-invocation/native/programs/lever/Cargo.toml
+++ b/basics/cross-program-invocation/native/programs/lever/Cargo.toml
@@ -9,7 +9,6 @@ cpi = ["no-entrypoint"]
 
 [dependencies]
 borsh = "1.5.7"
-borsh-derive = "0.10"
 solana-program = "2.0"
 
 [lib]

--- a/basics/cross-program-invocation/native/programs/lever/Cargo.toml
+++ b/basics/cross-program-invocation/native/programs/lever/Cargo.toml
@@ -8,7 +8,7 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-borsh = "0.10"
+borsh = "1.5.7"
 borsh-derive = "0.10"
 solana-program = "2.0"
 

--- a/basics/cross-program-invocation/native/programs/lever/src/lib.rs
+++ b/basics/cross-program-invocation/native/programs/lever/src/lib.rs
@@ -1,4 +1,4 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 #[cfg(not(feature = "no-entrypoint"))]
 use solana_program::entrypoint;
 use solana_program::{
@@ -42,7 +42,7 @@ pub fn initialize(
     let user = next_account_info(accounts_iter)?;
     let system_program = next_account_info(accounts_iter)?;
 
-    let account_span = (power_status.try_to_vec()?).len();
+    let account_span = (to_vec(&power_status))?.len();
     let lamports_required = (Rent::get()?).minimum_balance(account_span);
 
     invoke(


### PR DESCRIPTION
# Build and Test Fixes

The program was not building and test cases were failing. I made several changes to fix these issues:

## Changes Made

**1. Updated Borsh Dependency**
- Changed borsh version from `0.10` to `1.5.7` to fix build errors when running `pnpm run build-and-test`

**Error Fixed:**
```
error[E0277]: the trait bound `SetPowerStatus: borsh::ser::BorshSerialize` is not satisfied
  --> programs/hand/src/lib.rs:27:9
   |
25 |     let ix = Instruction::new_with_borsh(
   |              --------------------------- required by a bound introduced by this call
26 |         *lever_program.key,                        // Our lever program's ID
27 |         &set_power_status_instruction,             // Passing instructions through
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `borsh::ser::BorshSerialize` is not implemented for `SetPowerStatus`
   |
```

**2. Updated Borsh API Call**
- Changed `.try_to_vec()` to `.to_vec()` to match the latest version of borsh

**3. Updated Test Architecture**
- Changed the test architecture to use bankrun