### PR TITLE
Fix to deposit liquidity functions

### DIFF
--- a/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
@@ -37,13 +37,16 @@ pub fn deposit_liquidity(
         // Add as is if there is no liquidity
         (amount_a, amount_b)
     } else {
-        let ratio = I64F64::from_num(pool_a.amount)
-            .checked_mul(I64F64::from_num(pool_b.amount))
+        let amount_ratio = I64F64::from_num(amount_a)
+            .checked_div(I64F64::from_num(amount_b))
             .unwrap();
-        if pool_a.amount > pool_b.amount {
+        let pool_ratio = I64F64::from_num(pool_a.amount)
+            .checked_div(I64F64::from_num(pool_b.amount))
+            .unwrap();
+        if pool_ratio > amount_ratio {
             (
                 I64F64::from_num(amount_b)
-                    .checked_mul(ratio)
+                    .checked_mul(pool_ratio)
                     .unwrap()
                     .to_num::<u64>(),
                 amount_b,
@@ -52,7 +55,7 @@ pub fn deposit_liquidity(
             (
                 amount_a,
                 I64F64::from_num(amount_a)
-                    .checked_div(ratio)
+                    .checked_div(pool_ratio)
                     .unwrap()
                     .to_num::<u64>(),
             )

--- a/tokens/token-swap/steel/program/src/deposit_liquidity.rs
+++ b/tokens/token-swap/steel/program/src/deposit_liquidity.rs
@@ -86,18 +86,21 @@ pub fn process_deposit_liquidity(accounts: &[AccountInfo<'_>], data: &[u8]) -> P
         // Add as is if there is no liquidity
         (amount_a, amount_b)
     } else {
-        let ratio = U256::from(pool_account_a.amount)
-            .checked_mul(U256::from(pool_account_b.amount))
+        let amount_ratio = U256::from(amount_a)
+            .checked_div(U256::from(amount_b))
             .unwrap();
-        if pool_account_a.amount > pool_account_b.amount {
+        let pool_ratio = U256::from(pool_account_a.amount())
+            .checked_div(U256::from(pool_account_b.amount()))
+            .unwrap();
+        if pool_ratio > amount_ratio {
             (
-                U256::from(amount_b).checked_mul(ratio).unwrap().as_u64(),
+                U256::from(amount_b).checked_mul(pool_ratio).unwrap().as_u64(),
                 amount_b,
             )
         } else {
             (
                 amount_a,
-                U256::from(amount_a).checked_div(ratio).unwrap().as_u64(),
+                U256::from(amount_a).checked_div(pool_ratio).unwrap().as_u64(),
             )
         }
     };


### PR DESCRIPTION
It seems that the deposit liquidity functions are incorrect in both the anchor and steel folders in token-swap.

To deposit liquidity, we check that the amounts being deposited are in the same proportion as the existing liquidity in the pool. If not, we adjust the amounts accordingly. The resulting amounts are the maximum amounts available of the depositors tokens that satisfy the correct proportion.

Since these program examples are meant to be relatively simple, the fix has been made without introducing auxiliary functions.