### PR TITLE
fix: correct ratio calculation from multiplication to division in dep…

### DIFF
--- a/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
@@ -38,7 +38,7 @@ pub fn deposit_liquidity(
         (amount_a, amount_b)
     } else {
         let ratio = I64F64::from_num(pool_a.amount)
-            .checked_mul(I64F64::from_num(pool_b.amount))
+            .checked_div(I64F64::from_num(pool_b.amount))
             .unwrap();
         if pool_a.amount > pool_b.amount {
             (


### PR DESCRIPTION
Replace multiplication with division when calculating pool ratio
to maintain correct proportions during deposits