### PR TITLE
Update --bpf-out-dir to --sbf-out-dir

### DIFF
--- a/basics/account-data/native/cicd.sh
+++ b/basics/account-data/native/cicd.sh
@@ -4,5 +4,5 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
 solana program deploy ./program/target/so/program.so

--- a/basics/checking-accounts/native/cicd.sh
+++ b/basics/checking-accounts/native/cicd.sh
@@ -4,5 +4,5 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
 solana program deploy ./program/target/so/program.so

--- a/basics/close-account/native/cicd.sh
+++ b/basics/close-account/native/cicd.sh
@@ -4,5 +4,5 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
 solana program deploy ./program/target/so/program.so

--- a/basics/create-account/native/cicd.sh
+++ b/basics/create-account/native/cicd.sh
@@ -4,5 +4,5 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
 solana program deploy ./program/target/so/program.so

--- a/basics/cross-program-invocation/native/cicd.sh
+++ b/basics/cross-program-invocation/native/cicd.sh
@@ -4,7 +4,7 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --bpf-out-dir=./target/so
+cargo build-sbf --sbf-out-dir=./target/so
 echo "Hand:"
 solana program deploy ./target/so/hand.so | grep "Program Id:"
 echo "Lever:"

--- a/basics/favorites/native/cicd.sh
+++ b/basics/favorites/native/cicd.sh
@@ -4,5 +4,5 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
 solana program deploy ./program/target/so/program.so

--- a/basics/hello-solana/native/cicd.sh
+++ b/basics/hello-solana/native/cicd.sh
@@ -4,5 +4,5 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
 solana program deploy ./program/target/so/program.so

--- a/basics/pda-rent-payer/native/cicd.sh
+++ b/basics/pda-rent-payer/native/cicd.sh
@@ -4,5 +4,5 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
 solana program deploy ./program/target/so/program.so

--- a/basics/processing-instructions/native/cicd.sh
+++ b/basics/processing-instructions/native/cicd.sh
@@ -4,5 +4,5 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
 solana program deploy ./program/target/so/program.so

--- a/basics/program-derived-addresses/native/cicd.sh
+++ b/basics/program-derived-addresses/native/cicd.sh
@@ -4,5 +4,5 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
 solana program deploy ./program/target/so/program.so

--- a/basics/realloc/native/cicd.sh
+++ b/basics/realloc/native/cicd.sh
@@ -4,5 +4,5 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
 solana program deploy ./program/target/so/program.so

--- a/basics/rent/native/cicd.sh
+++ b/basics/rent/native/cicd.sh
@@ -4,5 +4,5 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
 solana program deploy ./program/target/so/program.so

--- a/basics/repository-layout/native/cicd.sh
+++ b/basics/repository-layout/native/cicd.sh
@@ -4,5 +4,5 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
 solana program deploy ./program/target/so/program.so

--- a/basics/transfer-sol/native/cicd.sh
+++ b/basics/transfer-sol/native/cicd.sh
@@ -4,5 +4,5 @@
 # It also serves as a reference for the commands used for building & deploying Solana programs.
 # Run this bad boy with "bash cicd.sh" or "./cicd.sh"
 
-cargo build-sbf --manifest-path=./program/Cargo.toml --bpf-out-dir=./program/target/so
+cargo build-sbf --manifest-path=./program/Cargo.toml --sbf-out-dir=./program/target/so
 solana program deploy ./program/target/so/program.so


### PR DESCRIPTION
Hello, I'm a Solana newbie and this is my first time contributing to this project.

I tried running some of the native examples but got the following error:

```console
$ bash basics/account-data/native/cicd.sh
error: Found argument '--bpf-out-dir' which wasn't expected, or isn't valid in this context

        Did you mean '--sbf-out-dir'?

        If you tried to supply `--bpf-out-dir` as a value rather than a flag, use `-- --bpf-out-dir`

USAGE:
    cargo-build-sbf --manifest-path <PATH> --sbf-out-dir <DIRECTORY>
```

So I have updated all the `cicd.sh` scripts to use `--sbf-out-dir` instead of `--bpf-out-dir`.

By the way, are these `cicd.sh` scripts supposed to run as part of the CI/CD? If so, I can try hooking them up in the next pull request.