### PR TITLE
Clarify usage for native tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repo contains Solana onchain programs (referred to as 'Smart Contracts' in 
 Each folder includes examples for one or more of the following:
 
 - `anchor` - Written using [Anchor](https://www.anchor-lang.com/), the most popular framework for Solana Development, which uses Rust. Use `anchor build && anchor deploy` to build & deploy the program. Run `anchor run test` to test it.
-- `native` - Written using Solana's native Rust crates and vanilla Rust. Use `cicd.sh` to build & deploy the program. Run `yarn run test` to test it.
+- `native` - Written using Solana's native Rust crates and vanilla Rust. Use `cicd.sh` to build & deploy the program. Use `yarn run test` to run the TypeScript tests and use `cargo build-sbf && cargo test` to run the Rust tests.
 
 **If a given example is missing, please send us a PR to add it!** Our aim is to have every example available in every option. We'd also love to see more programs involving staking, wrapped tokens, oracles, compression and VRF. Follow the [contributing guidelines](./CONTRIBUTING.md) to keep things consistent.
 


### PR DESCRIPTION
It wasn't clear to me at first that there are both TypeScript and Rust tests for the native examples, so I've attempted to clarify it a bit in the README.

By the way, the [workflow actions](https://github.com/solana-developers/program-examples/blob/main/.github/workflows/solana-native.yml#L150) are running `pnpm build-and-test` instead of `yarn run test` as stated in the README. If `pnpm build-and-test` is the new preferred way to run the tests then I can update that part in the README too.