### PR TITLE
correct the typo in swap_exact_token_for_tokens

### DIFF
--- a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs
@@ -134,7 +134,7 @@ pub fn swap_exact_tokens_for_tokens(
     // We tolerate if the new invariant is higher because it means a rounding error for LPs
     ctx.accounts.pool_account_a.reload()?;
     ctx.accounts.pool_account_b.reload()?;
-    if invariant > ctx.accounts.pool_account_a.amount * ctx.accounts.pool_account_a.amount {
+    if invariant > ctx.accounts.pool_account_a.amount * ctx.accounts.pool_account_b.amount {
         return err!(TutorialError::InvariantViolated);
     }
 


### PR DESCRIPTION
Fixed Typo

<img width="792" height="67" alt="Screenshot 2025-12-18 at 1 02 24 PM" src="https://github.com/user-attachments/assets/b35270ad-8adc-4df0-9d27-64b6ee6a024e" />

Change made
<img width="740" height="62" alt="Screenshot 2025-12-18 at 1 02 46 PM" src="https://github.com/user-attachments/assets/13102b1a-cef4-4b8c-819e-7f518fbcf7f7" />
