### PR TITLE
fix: send escrow vault rent back to maker

### DIFF
--- a/tokens/escrow/anchor/programs/escrow/src/instructions/take_offer.rs
+++ b/tokens/escrow/anchor/programs/escrow/src/instructions/take_offer.rs
@@ -115,7 +115,7 @@ pub fn withdraw_and_close_vault(ctx: Context<TakeOffer>) -> Result<()> {
 
     let accounts = CloseAccount {
         account: ctx.accounts.vault.to_account_info(),
-        destination: ctx.accounts.taker.to_account_info(),
+        destination: ctx.accounts.maker.to_account_info(),
         authority: ctx.accounts.offer.to_account_info(),
     };
 


### PR DESCRIPTION
The escrow maker paid for the vault rent, so they should get it back upon its closure not the taker.

This is practically negligible but semantically important for a learning resource : )