### PR TITLE
fix(tokens/token-swap): deposit ratio bug

### DIFF
--- a/tokens/token-swap/anchor/tests/deposit-liquidity.ts
+++ b/tokens/token-swap/anchor/tests/deposit-liquidity.ts
@@ -66,4 +66,114 @@ describe('Deposit liquidity', () => {
     const depositTokenAccountB = await connection.getTokenAccountBalance(values.holderAccountB);
     expect(depositTokenAccountB.value.amount).to.equal(values.defaultSupply.sub(values.depositAmountA).toString());
   });
-});
+
+  it('Deposit with existing liquidity (same ratio)', async () => {
+    // 1. Initial Deposit
+    await program.methods
+      .depositLiquidity(values.depositAmountA, values.depositAmountA)
+      .accounts({
+        pool: values.poolKey,
+        poolAuthority: values.poolAuthority,
+        depositor: values.admin.publicKey,
+        mintLiquidity: values.mintLiquidity,
+        mintA: values.mintAKeypair.publicKey,
+        mintB: values.mintBKeypair.publicKey,
+        poolAccountA: values.poolAccountA,
+        poolAccountB: values.poolAccountB,
+        depositorAccountLiquidity: values.liquidityAccount,
+        depositorAccountA: values.holderAccountA,
+        depositorAccountB: values.holderAccountB,
+      })
+      .signers([values.admin])
+      .rpc({ skipPreflight: true });
+
+    // 2. Second Deposit
+    const secondDepositAmount = new anchor.BN(100000);
+    await program.methods
+      .depositLiquidity(secondDepositAmount, secondDepositAmount)
+      .accounts({
+        pool: values.poolKey,
+        poolAuthority: values.poolAuthority,
+        depositor: values.admin.publicKey,
+        mintLiquidity: values.mintLiquidity,
+        mintA: values.mintAKeypair.publicKey,
+        mintB: values.mintBKeypair.publicKey,
+        poolAccountA: values.poolAccountA,
+        poolAccountB: values.poolAccountB,
+        depositorAccountLiquidity: values.liquidityAccount,
+        depositorAccountA: values.holderAccountA,
+        depositorAccountB: values.holderAccountB,
+      })
+      .signers([values.admin])
+      .rpc({ skipPreflight: true });
+
+    const poolAccountA = await connection.getTokenAccountBalance(values.poolAccountA);
+    expect(poolAccountA.value.amount).to.equal(values.depositAmountA.add(secondDepositAmount).toString());
+  });
+
+  it('Deposit with different ratio', async () => {
+    // 1. Initial Deposit with 1:5 ratio
+    // Pool A: 1,000,000
+    // Pool B: 5,000,000
+    const initialAmountA = new anchor.BN(1_000_000);
+    const initialAmountB = new anchor.BN(5_000_000);
+
+    await program.methods
+      .depositLiquidity(initialAmountA, initialAmountB)
+      .accounts({
+        pool: values.poolKey,
+        poolAuthority: values.poolAuthority,
+        depositor: values.admin.publicKey,
+        mintLiquidity: values.mintLiquidity,
+        mintA: values.mintAKeypair.publicKey,
+        mintB: values.mintBKeypair.publicKey,
+        poolAccountA: values.poolAccountA,
+        poolAccountB: values.poolAccountB,
+        depositorAccountLiquidity: values.liquidityAccount,
+        depositorAccountA: values.holderAccountA,
+        depositorAccountB: values.holderAccountB,
+      })
+      .signers([values.admin])
+      .rpc({ skipPreflight: true });
+
+        // 2. Second Deposit with mismatched input
+        // Input A: 500,000
+        // Input B: 500,000
+        // Logic:
+        // - 500k A requires 2.5M B. (User only provided 500k B).
+        // - 500k B requires 100k A. (User provided 500k A).
+        // Result: Deposit 100k A and 500k B.
+        const secondDepositA = new anchor.BN(500000);
+        const secondDepositBInput = new anchor.BN(500000);
+    
+        await program.methods
+          .depositLiquidity(secondDepositA, secondDepositBInput)
+          .accounts({
+            pool: values.poolKey,
+            poolAuthority: values.poolAuthority,
+            depositor: values.admin.publicKey,
+            mintLiquidity: values.mintLiquidity,
+            mintA: values.mintAKeypair.publicKey,
+            mintB: values.mintBKeypair.publicKey,
+            poolAccountA: values.poolAccountA,
+            poolAccountB: values.poolAccountB,
+            depositorAccountLiquidity: values.liquidityAccount,
+            depositorAccountA: values.holderAccountA,
+            depositorAccountB: values.holderAccountB,
+          })
+          .signers([values.admin])
+          .rpc({ skipPreflight: true });
+    
+        // 3. Verify Balances
+        const poolAccountA = await connection.getTokenAccountBalance(values.poolAccountA);
+        const poolAccountB = await connection.getTokenAccountBalance(values.poolAccountB);
+    
+        // Total A: 1,000,000 + 100,000 = 1,100,000
+        // We expect 100,000 A to be deposited.
+        const expectedAdditionalA = secondDepositBInput.mul(initialAmountA).div(initialAmountB); // 500k * (1M/5M) = 100k
+        expect(poolAccountA.value.amount).to.equal(initialAmountA.add(expectedAdditionalA).toString());
+        
+        // Total B: 5,000,000 + 500,000 = 5,500,000
+        expect(poolAccountB.value.amount).to.equal(initialAmountB.add(secondDepositBInput).toString());
+      });
+    });


### PR DESCRIPTION
In the Token Swap program example,

The current `deposit_liquidity` instruction checks the existing liquidity to establish a `tokenA/tokenB` ratio, but it has a bug.

https://github.com/solana-developers/program-examples/blob/8e0879be582cce5436a54861deb1d5cf90e1cdd7/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs#L40-L60

Specifically here (notice the multiplication instead of division)
```rust
 let ratio = I64F64::from_num(pool_a.amount) 
         .checked_mul(I64F64::from_num(pool_b.amount)) 
         .unwrap(); 
```

I fixed that and added a tests to verify the desired behavior:
1. deposit the same ratio as the pool 
2. handle deposits of a different ratio