### PR TITLE
correct deposit liquidity ratio #505

### DIFF
--- a/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
@@ -38,7 +38,7 @@ pub fn deposit_liquidity(
         (amount_a, amount_b)
     } else {
         let ratio = I64F64::from_num(pool_a.amount)
-            .checked_mul(I64F64::from_num(pool_b.amount))
+            .checked_div(I64F64::from_num(pool_b.amount))
             .unwrap();
         if pool_a.amount > pool_b.amount {
             (

--- a/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
@@ -40,22 +40,21 @@ pub fn deposit_liquidity(
         let ratio = I64F64::from_num(pool_a.amount)
             .checked_div(I64F64::from_num(pool_b.amount))
             .unwrap();
-        if pool_a.amount > pool_b.amount {
-            (
-                I64F64::from_num(amount_b)
-                    .checked_mul(ratio)
-                    .unwrap()
-                    .to_num::<u64>(),
-                amount_b,
-            )
+
+        // Calculate the optimal amount of A needed for the given amount of B
+        let optimal_amount_a = I64F64::from_num(amount_b)
+            .checked_mul(ratio)
+            .unwrap()
+            .to_num::<u64>();
+
+        if optimal_amount_a <= amount_a {
+            (optimal_amount_a, amount_b)
         } else {
-            (
-                amount_a,
-                I64F64::from_num(amount_a)
-                    .checked_div(ratio)
-                    .unwrap()
-                    .to_num::<u64>(),
-            )
+            let optimal_amount_b = I64F64::from_num(amount_a)
+                .checked_div(ratio)
+                .unwrap()
+                .to_num::<u64>();
+            (amount_a, optimal_amount_b)
         }
     };
 

--- a/tokens/token-swap/anchor/programs/token-swap/src/lib.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/lib.rs
@@ -6,7 +6,7 @@ mod instructions;
 mod state;
 
 // Set the correct key here
-declare_id!("AsGVFxWqEn8icRBFQApxJe68x3r9zvfSbmiEzYFATGYn");
+declare_id!("Bb8CYNtpoqQUR4t2JaoMH8uwVCmjBWiVbBVqeXBcSM93");
 
 #[program]
 pub mod swap_example {


### PR DESCRIPTION
This PR fixes two critical logic bugs in the deposit_liquidity instruction:

1.  Ratio Calculation Fix: The code was incorrectly multiplying pool amounts (pool_a * pool_b) instead of dividing (pool_a / pool_b) to determine the current pool ratio. This led to incorrect LP token calculations.

2. Arbitrarily selected which input amount to use based on if pool_a > pool_b, which could cause transactions to fail even when users provided sufficient funds

    - Calculate optimal amount_a based on provided amount_b
    - If optimal amount_a fits within user's input, use it
    - Otherwise, calculate optimal amount_b based on provided amount_a
    - Guarantees deposits succeed using maximum possible liquidity within user's constraints
