### PR TITLE
Fix invariant check in token-swap swap function

### DIFF
--- a/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/instructions/swap_exact_tokens_for_tokens.rs
@@ -134,7 +134,7 @@ pub fn swap_exact_tokens_for_tokens(
     // We tolerate if the new invariant is higher because it means a rounding error for LPs
     ctx.accounts.pool_account_a.reload()?;
     ctx.accounts.pool_account_b.reload()?;
-    if invariant > ctx.accounts.pool_account_a.amount * ctx.accounts.pool_account_a.amount {
+    if invariant > ctx.accounts.pool_account_a.amount * ctx.accounts.pool_account_b.amount {
         return err!(TutorialError::InvariantViolated);
     }
 


### PR DESCRIPTION
## Summary
- Fixed the invariant check in `swap_exact_tokens_for_tokens.rs` at line 137
- Changed `pool_account_a.amount * pool_account_a.amount` to `pool_account_a.amount * pool_account_b.amount`
- This correctly verifies the constant product invariant (x * y = k) used in the CPAMM

## Test plan
- The change is straightforward and corrects an obvious typo
- The invariant check should now properly compare against the product of both token amounts

Fixes #477