### PR TITLE
Fix typos and documentation issues across multiple READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Close an account and get the Lamports back.
 
 [anchor](./basics/processing-instructions/anchor) [native](./basics/processing-instructions/native)
 
-### Storing date in program derived addresses
+### Storing data in program derived addresses
 
 Store and retrieve state in Solana.
 
@@ -175,7 +175,7 @@ Allow two users to swap digital assets with each other, each getting 100% of wha
 
 ### Basics - create token mints, mint tokens, and transfer tokens with Token Extensions
 
-Create token mints, mint tokens, and transferr tokens using Token Extensions.
+Create token mints, mint tokens, and transfer tokens using Token Extensions.
 
 [anchor](./tokens/token-2022/basics/anchor)
 
@@ -221,13 +221,13 @@ Create tokens that store their onchain metadata inside the token mint, without n
 
 [anchor](./tokens/token-2022/metadata/anchor)
 
-### Allow a designedated account to close a mint
+### Allow a designated account to close a mint
 
 Allow a designated account to close a Mint.
 
 [anchor](./tokens/token-2022/mint-close-authority/anchor) [native](./tokens/token-2022/mint-close-authority/native)
 
-### Usng multiple token extensions
+### Using multiple token extensions
 
 Use multiple Token Extensions at once.
 

--- a/basics/favorites/anchor/README.md
+++ b/basics/favorites/anchor/README.md
@@ -2,7 +2,7 @@
 
 This is a basic Anchor app using PDAs to store data for a user, and Anchor's account checks to ensure each user is only allowed to modify their own data.
 
-It's used by the [https://github.com/solana-developers/professional-education](Solana Professional Education) course.
+It's used by the [Solana Professional Education](https://github.com/solana-developers/professional-education) course.
 
 ## Usage
 

--- a/basics/pda-rent-payer/README.md
+++ b/basics/pda-rent-payer/README.md
@@ -1,5 +1,5 @@
 # PDA Rent-Payer
 
-This examples demonstrates how to use a PDA to pay the rent for the creation of a new account.   
+This example demonstrates how to use a PDA to pay the rent for the creation of a new account.   
    
 The key here is accounts on Solana are automatically created under ownership of the System Program when you transfer lamports to them. So, you can just transfer lamports from your PDA to the new account's public key!

--- a/compression/cnft-vault/anchor/README.md
+++ b/compression/cnft-vault/anchor/README.md
@@ -4,7 +4,7 @@ This repo contains example code of how you can work with Metaplex compressed NFT
 
 The basic idea is to allow for transfering cNFTs that are owned by a PDA account. So our program will have a vault (this PDA) that you can send cNFTs to manually and then withdraw them using the program instructions.
 
-There are two instructions: one simple transfer that can withdraw one cNFT, and one instructions that can withdraw two cNFTs at the same time.
+There are two instructions: one simple transfer that can withdraw one cNFT, and one instruction that can withdraw two cNFTs at the same time.
 
 This program can be used as an inspiration on how to work with cNFTs in Solana programs.
 
@@ -19,10 +19,10 @@ You can deploy it yourself by changing the respective values in lib.rs and Ancho
 
 ## Limitations
 
-This is just an example implementation. It is missing all logic wheter a transfer should be performed or not (everyone can withdraw any cNFT in the vault). 
-Furthermore it is not optimized for using lowest possible compute. It is intended as a proof of concept and reference implemention only. 
+This is just an example implementation. It is missing all logic whether a transfer should be performed or not (everyone can withdraw any cNFT in the vault).
+Furthermore it is not optimized for using lowest possible compute. It is intended as a proof of concept and reference implementation only. 
 
 ## Further resources
 
-A video about the creation of this code which also contains further explanations has been publised on Solandy's YouTube channel:
+A video about the creation of this code which also contains further explanations has been published on Solandy's YouTube channel:
 https://youtu.be/qzr-q_E7H0M

--- a/compression/cutils/anchor/README.md
+++ b/compression/cutils/anchor/README.md
@@ -29,7 +29,7 @@ This is just an example implementation. Use at your own discretion
 **This only works on anchor 0.26.0 for now due to mpl-bubblegum dependencies** 
 
 ## Further resources
-A video about the creation of this code which also contains further explanations has been publised on Burger Bob's YouTube channel: COMING SOON
+A video about the creation of this code which also contains further explanations has been published on Burger Bob's YouTube channel: COMING SOON
 
 ## How-to
 1. Configure RPC path in _utils/readAPI.ts_. Personal preference: Helius RPCs.

--- a/tokens/escrow/anchor/README.md
+++ b/tokens/escrow/anchor/README.md
@@ -22,7 +22,7 @@ This project is based on [Dean Little's Anchor Escrow,](https://github.com/deanm
 
 ### Changes from original
 
-One of the challenges when teaching is avoiding ambiguity — names have to be carefully chosen to be clear and not possible to confuse with other times.
+One of the challenges when teaching is avoiding ambiguity — names have to be carefully chosen to be clear and not possible to confuse with other items.
 
 - Custom instructions were replaced by `@solana-developers/helpers` for many tasks to reduce the file size.
 - Shared functionality to transfer tokens is now in `instructions/shared.rs`


### PR DESCRIPTION
## Summary
- Fixed various typos and documentation issues across multiple README files

### Changes:
- **README.md**: 
  - "Storing date in program derived addresses" -> "Storing data in program derived addresses"
  - "transferr tokens" -> "transfer tokens"
  - "designedated account" -> "designated account"
  - "Usng multiple token extensions" -> "Using multiple token extensions"

- **basics/pda-rent-payer/README.md**: 
  - "This examples demonstrates" -> "This example demonstrates"

- **compression/cnft-vault/anchor/README.md**: 
  - "one instructions that can withdraw" -> "one instruction that can withdraw"
  - "wheter a transfer" -> "whether a transfer"
  - "reference implemention" -> "reference implementation"
  - "publised on Solandy's" -> "published on Solandy's"

- **compression/cutils/anchor/README.md**: 
  - "publised on Burger Bob's" -> "published on Burger Bob's"

- **basics/favorites/anchor/README.md**: 
  - Fixed malformed markdown link (swapped text and URL)

- **tokens/escrow/anchor/README.md**: 
  - "confuse with other times" -> "confuse with other items"

## Test plan
- Documentation-only changes, no code affected