### PR TITLE
fix(transfer-sol): require payer signature + checked lamport math

### DIFF
--- a/basics/transfer-sol/anchor/tests/test.ts
+++ b/basics/transfer-sol/anchor/tests/test.ts
@@ -58,6 +58,7 @@ describe("Anchor: Transfer SOL", () => {
 				payer: payerAccount.publicKey,
 				recipient: recipientAccount.publicKey,
 			})
+			.signers([payerAccount])
 			.rpc();
 
 		const recipientBalance = await provider.connection.getBalance(


### PR DESCRIPTION
This fixes a dangerous footgun in the Anchor transfer-sol example.

Problem:
- `transfer_sol_with_program` mutates lamports of a program-owned `payer` account but previously did not require the payer to sign.
- If copied into production code, this pattern allows unauthorized SOL drain from program-owned accounts passed as `payer`.

Fix:
- Require `payer: Signer<'info>` while keeping `owner = id()` constraint.
- Use checked lamport arithmetic + explicit insufficient funds checks.
- Update the test to include `.signers([payerAccount])`.