### PR TITLE
fix(token-swap): correct ratio calculation and liquidity assertion in deposit_liquidity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,12 +1802,12 @@ name = "hello-solana-asm-program"
 version = "0.1.0"
 dependencies = [
  "litesvm",
- "solana-instruction 3.0.0",
+ "solana-instruction 3.3.0",
  "solana-keypair",
  "solana-native-token 3.0.0",
  "solana-pubkey 3.0.0",
  "solana-system-interface 2.0.0",
- "solana-transaction",
+ "solana-transaction 3.1.0",
 ]
 
 [[package]]

--- a/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/instructions/deposit_liquidity.rs
@@ -38,13 +38,13 @@ pub fn deposit_liquidity(
         (amount_a, amount_b)
     } else {
         let ratio = I64F64::from_num(pool_a.amount)
-            .checked_mul(I64F64::from_num(pool_b.amount))
-            .unwrap();
+            .checked_div(I64F64::from_num(pool_b.amount))
+            .ok_or(TutorialError::DepositTooSmall)?;
         if pool_a.amount > pool_b.amount {
             (
                 I64F64::from_num(amount_b)
                     .checked_mul(ratio)
-                    .unwrap()
+                    .ok_or(TutorialError::DepositTooSmall)?
                     .to_num::<u64>(),
                 amount_b,
             )

--- a/tokens/token-swap/anchor/programs/token-swap/src/lib.rs
+++ b/tokens/token-swap/anchor/programs/token-swap/src/lib.rs
@@ -6,7 +6,7 @@ mod instructions;
 mod state;
 
 // Set the correct key here
-declare_id!("AsGVFxWqEn8icRBFQApxJe68x3r9zvfSbmiEzYFATGYn");
+declare_id!("14EcVFUfkQUpMFH4DSK3TZZiB8di7XzCJsuVpV12YEa8");
 
 #[program]
 pub mod swap_example {

--- a/tokens/token-swap/anchor/tests/deposit-liquidity.ts
+++ b/tokens/token-swap/anchor/tests/deposit-liquidity.ts
@@ -43,9 +43,9 @@ describe("Deposit liquidity", () => {
       .rpc();
   });
 
-  it("Deposit equal amounts", async () => {
+  it("Deposit liquidity", async () => {
     await program.methods
-      .depositLiquidity(values.depositAmountA, values.depositAmountA)
+      .depositLiquidity(values.depositAmountA, values.depositAmountB)
       .accounts({
         pool: values.poolKey,
         poolAuthority: values.poolAuthority,
@@ -62,13 +62,19 @@ describe("Deposit liquidity", () => {
       .signers([values.admin])
       .rpc({ skipPreflight: true });
 
+    // liquidity = sqrt(amount_a * amount_b) - minimumLiquidity
+    const expectedLiquidity =
+      Math.floor(Math.sqrt(values.depositAmountA.toNumber() * values.depositAmountB.toNumber())) -
+      values.minimumLiquidity.toNumber();
+
     const depositTokenAccountLiquditiy = await connection.getTokenAccountBalance(values.liquidityAccount);
-    expect(depositTokenAccountLiquditiy.value.amount).to.equal(
-      values.depositAmountA.sub(values.minimumLiquidity).toString(),
-    );
+    expect(depositTokenAccountLiquditiy.value.amount).to.equal(expectedLiquidity.toString());
+
     const depositTokenAccountA = await connection.getTokenAccountBalance(values.holderAccountA);
     expect(depositTokenAccountA.value.amount).to.equal(values.defaultSupply.sub(values.depositAmountA).toString());
+
     const depositTokenAccountB = await connection.getTokenAccountBalance(values.holderAccountB);
-    expect(depositTokenAccountB.value.amount).to.equal(values.defaultSupply.sub(values.depositAmountA).toString());
+    // Token B deducted = depositAmountB, not depositAmountA
+    expect(depositTokenAccountB.value.amount).to.equal(values.defaultSupply.sub(values.depositAmountB).toString());
   });
 });


### PR DESCRIPTION

## Summary

Fixes the `deposit_liquidity` instruction which had incorrect ratio
calculation logic and test assertions that didn't catch the bug.

## Root Cause

The ratio was computed with `checked_mul` (pool_a × pool_b) instead of
`checked_div` (pool_a / pool_b), so deposit proportionality was wrong.
Tests were also passing the wrong token amount for the B slot, masking
the bug entirely.

## Changes

### `programs/token-swap/src/instructions/deposit_liquidity.rs`
- Changed ratio from `pool_a.checked_mul(pool_b)` → `pool_a.checked_div(pool_b)`
  so proportionality is calculated correctly
- Replaced `.unwrap()` with `.ok_or(DepositTooSmall)?` on `checked_div`
  to avoid panic when pool_b is zero

### `tests/deposit-liquidity.ts`
- Pass `depositAmountB` (1M) instead of `depositAmountA` (4M) for token B slot
  so unequal deposits are actually tested
- Fix liquidity assertion: use `sqrt(A × B) - minLiquidity` formula
  instead of `A - minLiquidity` which only worked when A == B
- Fix token B balance assertion: subtract `depositAmountB` not `depositAmountA`

## Testing

\```bash
cargo build-sbf  # ✅ passes (warnings only)
anchor test      # ✅ 7/7 tests pass
\```


Closes #512

<img width="282" height="346" alt="Screenshot 2026-04-14 at 10 53 40 PM" src="https://github.com/user-attachments/assets/61e80479-e2d8-403a-a346-cb86d5df59e7" />