### PR TITLE
ci: pin sbpf and Solana versions in ASM workflow

### DIFF
--- a/.github/workflows/solana-asm.yml
+++ b/.github/workflows/solana-asm.yml
@@ -190,12 +190,19 @@ jobs:
           # latest pnpm fails CI with ERR_PNPM_IGNORED_BUILDS)
           npm install --global pnpm@10.33.0
 
-          # Install sbpf assembler
-          cargo install --git https://github.com/blueshift-gg/sbpf.git
+          # Install sbpf assembler. Pinned to v0.1.9 (0223df0e): the unpinned
+          # tip moved to v0.2.2, which emits an sBPF binary the runtime loader
+          # rejects at execution ("Program is not deployed"), breaking every ASM
+          # example. Keep in sync with the pinned Solana version below.
+          cargo install --git https://github.com/blueshift-gg/sbpf.git --rev 0223df0e
       - name: Setup Solana Stable
         uses: heyAyushh/setup-solana@v5.9
         with:
-          solana-cli-version: stable
+          # Pinned to 4.0.3, the last version the ASM examples passed on (paired
+          # with sbpf v0.1.9 above). Floating "stable" moved to 4.1.1 in the same
+          # window the toolchain broke. The beta leg below stays unpinned on
+          # purpose (it is continue-on-error and tracks the moving channel).
+          solana-cli-version: 4.0.3
       - name: Build and Test with Stable
         run: |
           source build_and_test.sh

--- a/.github/workflows/solana-asm.yml
+++ b/.github/workflows/solana-asm.yml
@@ -194,7 +194,7 @@ jobs:
           # tip moved to v0.2.2, which emits an sBPF binary the runtime loader
           # rejects at execution ("Program is not deployed"), breaking every ASM
           # example. Keep in sync with the pinned Solana version below.
-          cargo install --git https://github.com/blueshift-gg/sbpf.git --rev 0223df0e
+          cargo install --git https://github.com/blueshift-gg/sbpf.git --rev 0223df0e7ba622d4956b4ecf3cf2397f6945b76b
       - name: Setup Solana Stable
         uses: heyAyushh/setup-solana@v5.9
         with:


### PR DESCRIPTION
## Problem

The ASM `build-and-test` job has been red on `main` since **2026-06-29**, failing every ASM example with:

```
Program is not deployed
Program ... failed: invalid account data for instruction
```

Tests that expect `custom program error: 0x1..0x6` instead get `invalid account data for instruction`, so `checking-accounts`, `create-account`, `hello-solana`, `transfer-sol` (and the rest of the ASM group) all fail.

## Root cause

`solana-asm.yml` installs both tools **unpinned**, so they drift with upstream:

| Tool | Last green (06-29 00:44 UTC) | Current |
|------|------------------------------|---------|
| `sbpf` | **v0.1.9** (`0223df0e`) | v0.2.2 (`54a3a273`) |
| `solana-cli` (`stable`) | **4.0.3** | 4.1.1 |

`sbpf` bumped 0.1.9 → 0.2.2 and now emits an sBPF binary the runtime loader rejects at execution ("Program is not deployed"). The build still succeeds; the failure is at load/execute time. No repo commit touched the ASM examples in the break window — it is pure toolchain drift.

## Fix

Pin to the exact last-green combination:
- `sbpf` → `--rev 0223df0e` (v0.1.9)
- Solana `stable` leg → `4.0.3`

The **beta** leg is intentionally left unpinned — it is already `continue-on-error` and is meant to track the moving channel, so it cannot fail the job.

## Note / follow-up

This restores CI by freezing the ASM toolchain to the last-known-good pair. A forward-fix (making the ASM examples compatible with `sbpf` 0.2.x / Solana 4.1.x) is the longer-term path and can be done separately; this unblocks the currently-red ASM check in the meantime.